### PR TITLE
refactor: update notification titles from PR body instead of PR title

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,27 +2,29 @@
 
 <!-- Briefly describe what this PR does. -->
 
-## Release Notes
+# Release Notes
 
 <!--
-  If this PR includes user-facing changes, add the `release-note` label
-  and describe the changes below. Each line becomes a bullet point in
-  the in-app update notification toast.
+  If this PR is user-facing, add the `release-note` label and follow the
+  format below exactly.
 
-  Delete this section if the PR is internal-only (e.g. refactors, CI, deps).
+  - Use `# Release Notes` (H1) as the section trigger — the automation
+    looks for this exact heading.
+  - Each `## Feature Title` (H2) becomes a notification heading in the toast.
+  - The plain text below each H2 becomes the description shown to users.
+  - Delete this entire section for internal-only PRs (refactors, CI, deps).
 
   EXAMPLE:
   ─────────────────────────────────────────────────────────────────────
-  ## Release Notes
+  # Release Notes
 
-  - Honor eligibility status is now shown instantly without reloading.
-  - Fixed an issue where INC grades were not counted correctly.
-  - Grade Converter now supports the APC 5-point scale.
+  ## Honor eligibility now updates instantly
+  Students no longer need to reload the page to see their updated honor status.
+
+  ## Grade Converter supports the APC 5-point scale
+  You can now convert grades using the new APC 5-point grading system.
   ─────────────────────────────────────────────────────────────────────
-  Each bullet becomes one line in the toast notification popup.
-  The PR title is shown as the heading above these bullets.
-  Leave this section out (or delete it) for chores, refactors, or hotfixes
-  that users don't need to know about.
 -->
 
-- 
+## Feature title here
+Short description of what changed and why it matters to the user. 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -353,10 +353,16 @@
 .update-toast__entry {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
-.update-toast__entry-title {
+.update-toast__feature {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.update-toast__feature-title {
   font-size: 0.8125rem;
   font-weight: 600;
   line-height: 1.4;
@@ -364,28 +370,11 @@
   margin: 0;
 }
 
-.update-toast__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-}
-
-.update-toast__item {
-  position: relative;
-  padding-left: 1rem;
+.update-toast__feature-desc {
   font-size: 0.8125rem;
   line-height: 1.5;
   color: var(--muted-foreground);
-}
-
-.update-toast__item::before {
-  content: "•";
-  position: absolute;
-  left: 0;
-  color: var(--foreground);
+  margin: 0;
 }
 
 .update-toast__cta {

--- a/src/components/UpdateToast.tsx
+++ b/src/components/UpdateToast.tsx
@@ -55,8 +55,12 @@ export function UpdateToast() {
 
   if (!visible) return null;
 
-  // Sort most-recent first for display
-  const sorted = [...unread].sort((a, b) => b.id - a.id);
+  // Sort most-recent first; skip entries that have no displayable features
+  const visibleEntries = [...unread]
+    .sort((a, b) => b.id - a.id)
+    .filter((e) => (e.features?.length ?? 0) > 0);
+
+  if (visibleEntries.length === 0) return null;
 
   return (
     <div
@@ -80,22 +84,20 @@ export function UpdateToast() {
         </button>
       </div>
 
-      {/* Grouped change list */}
+      {/* Feature list */}
       <div className="update-toast__entries">
-        {sorted.map((entry) => (
+        {visibleEntries.map((entry) => (
           <div key={entry.id} className="update-toast__entry">
-            {entry.title && (
-              <p className="update-toast__entry-title">{entry.title}</p>
-            )}
-            {entry.changes.length > 0 && (
-              <ul className="update-toast__list">
-                {entry.changes.map((change, i) => (
-                  <li key={i} className="update-toast__item">
-                    {change}
-                  </li>
-                ))}
-              </ul>
-            )}
+            {entry.features.map((feature, i) => (
+              <div key={i} className="update-toast__feature">
+                {feature.title && (
+                  <p className="update-toast__feature-title">{feature.title}</p>
+                )}
+                {feature.description && (
+                  <p className="update-toast__feature-desc">{feature.description}</p>
+                )}
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,14 +1,22 @@
 import generatedChangelog from "./changelog-generated.json";
 
+/** A single user-facing feature or fix inside a release entry. */
+export interface ReleaseFeature {
+  /** Human-readable title from the `## Heading` in the PR body. */
+  title: string;
+  /** Description text below the heading (lines joined into one string). */
+  description: string;
+}
+
 export interface ChangelogEntry {
   /** Unique ID — PR number when auto-generated, manual int otherwise. */
   id: number;
   /** ISO date string (YYYY-MM-DD). */
   date: string;
-  /** PR title or short headline. */
+  /** Raw PR title — kept for reference, not displayed in the toast. */
   title: string;
-  /** Optional detailed bullet points from the PR body's "## Release Notes" section. */
-  changes: string[];
+  /** User-facing features parsed from the PR body's `# Release Notes` section. */
+  features: ReleaseFeature[];
 }
 
 /**
@@ -27,9 +35,13 @@ const MANUAL_ENTRIES: ChangelogEntry[] = [
   // {
   //   id: 1,
   //   date: "2026-03-01",
-  //   title: "Latin Honors merged into Honors Calculator",
-  //   changes: [
-  //     "Latin Honors results are now shown directly on the Honors Calculator — no more switching between pages.",
+  //   title: "feat: latin honors merged",
+  //   features: [
+  //     {
+  //       title: "Latin Honors merged into Honors Calculator",
+  //       description:
+  //         "Latin Honors results are now shown directly on the Honors Calculator — no more switching between pages.",
+  //     },
   //   ],
   // },
 ];


### PR DESCRIPTION
Solving Issue #121
Testing changes made based on Issue #127 

# Release Notes
## Toast Notification
Latest updates will now show through this notification! Cheers in keeping you updated on the changes made in this site ^^
## Feature 2
Just testing how it would look like if 2 update logs were added in the notification
