### PR TITLE
Feat/lite mode

### DIFF
--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -29,71 +29,136 @@ interface LiteYearData {
   term1: string;
   term2: string;
   term3: string;
+  units1: string;
+  units2: string;
+  units3: string;
 }
 
-function calcLiteStats(data: LiteYearData): { gpa: number; eligible: string } {
+function calcLiteStats(data: LiteYearData): { gpa: number; eligible: string; totalUnits: number } {
   const t1 = parseFloat(data.term1);
   const t2 = parseFloat(data.term2);
   const t3 = parseFloat(data.term3);
 
+  const u1 = parseFloat(data.units1) || 0;
+  const u2 = parseFloat(data.units2) || 0;
+  const u3 = parseFloat(data.units3) || 0;
+  const totalUnits = u1 + u2 + u3;
+
   const values = [t1, t2, t3].filter(v => !isNaN(v) && v > 0);
-  if (values.length === 0) return { gpa: 0, eligible: '-' };
+  if (values.length === 0) return { gpa: 0, eligible: '-', totalUnits };
 
   const avg = values.reduce((a, b) => a + b, 0) / values.length;
 
-  // Same honors criteria as full mode — GPA between 3.0 and 4.0
   let eligible: string;
-  if (avg >= 3.0 && avg <= 4.0) eligible = "Yes";
-  else eligible = "No";
+  if (avg >= 3.0 && avg <= 4.0) {
+    if (totalUnits >= 36) eligible = "Yes";
+    else eligible = "No, not enough units (need 36)";
+  } else {
+    eligible = "No";
+  }
 
-  return { gpa: avg, eligible };
+  return { gpa: avg, eligible, totalUnits };
 }
 
-// Shared input style matching TermTable inputs
-function LiteInput({
-  label,
-  value,
-  onChange,
-  id,
+// ── Lite Mode row: Grade input (wider) + Units input (narrow) side by side ──
+function LiteTermRow({
+  termNum,
+  yearKey,
+  gradeValue,
+  unitsValue,
+  onGradeChange,
+  onUnitsChange,
+  onKeyDown,
 }: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  id: string;
+  termNum: number;
+  yearKey: string;
+  gradeValue: string;
+  unitsValue: string;
+  onGradeChange: (v: string) => void;
+  onUnitsChange: (v: string) => void;
+  onKeyDown: (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    type: "grade" | "units",
+    termNum: number,
+    yearKey: string
+  ) => void;
 }) {
   return (
-    <div className="flex flex-col gap-1">
-      <label htmlFor={id} className="text-xs text-muted-foreground font-medium">
-        {label}
-      </label>
-      <input
-        id={id}
-        type="number"
-        step="0.01"
-        min="0"
-        max="5"
-        value={value}
-        onChange={e => onChange(e.target.value)}
-        placeholder="0.00"
-        className="
-          w-28 rounded-md border border-input bg-background px-3 py-1.5
-          text-sm text-foreground shadow-sm
-          placeholder:text-muted-foreground/50
-          focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
-          transition-colors
-        "
-      />
+    <div className="flex flex-col gap-1.5">
+      {/* Term label */}
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        Term {termNum}
+      </p>
+
+      {/* Grade + Units side by side */}
+      <div className="flex items-end gap-2">
+        {/* Grade — wider */}
+        <div className="flex flex-col gap-1 flex-1">
+          <label
+            htmlFor={`lite-${yearKey}-grade-${termNum}`}
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Grade
+          </label>
+          <input
+            id={`lite-${yearKey}-grade-${termNum}`}
+            type="number"
+            step="0.01"
+            min="0"
+            max="5"
+            value={gradeValue}
+            onChange={e => onGradeChange(e.target.value)}
+            onKeyDown={e => onKeyDown(e, "grade", termNum, yearKey)}
+            placeholder="0.00"
+            className="
+              w-full rounded-md border border-input bg-background px-3 py-1.5
+              text-sm text-foreground shadow-sm
+              placeholder:text-muted-foreground/50
+              focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+              transition-colors
+            "
+          />
+        </div>
+
+        {/* Units — narrow pill */}
+        <div className="flex flex-col gap-1 w-14">
+          <label
+            htmlFor={`lite-${yearKey}-units-${termNum}`}
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Units
+          </label>
+          <input
+            id={`lite-${yearKey}-units-${termNum}`}
+            type="number"
+            step="1"
+            min="0"
+            value={unitsValue}
+            onChange={e => onUnitsChange(e.target.value)}
+            onKeyDown={e => onKeyDown(e, "units", termNum, yearKey)}
+            placeholder="0"
+            className="
+              w-full rounded-md border border-input bg-background px-2 py-1.5
+              text-sm text-center text-foreground shadow-sm
+              placeholder:text-muted-foreground/50
+              focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+              transition-colors
+            "
+          />
+        </div>
+      </div>
     </div>
   );
 }
+
 export default function HonorsCalcu() {
   const [termsData, setTermsData] = React.useState<Record<string, RowData[]>>({});
   const [liteMode, setLiteMode] = React.useState(true);
   const [liteData, setLiteData] = React.useState<Record<string, LiteYearData>>({
-    "Year 1": { term1: "", term2: "", term3: "" },
-    "Year 2": { term1: "", term2: "", term3: "" },
-    "Year 3": { term1: "", term2: "", term3: "" },
-    "Year 4": { term1: "", term2: "", term3: "" },
+    "Year 1": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    "Year 2": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    "Year 3": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    "Year 4": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
   });
 
   const termsDataRef = React.useRef(termsData);
@@ -116,13 +181,6 @@ export default function HonorsCalcu() {
           setLiteData(parsedLite);
         }
       }
-      const savedLiteMode = localStorage.getItem("honorsLiteMode");
-      if (savedLiteMode !== null) {
-        // We set it to true by default, but if they explicitly changed it in this session,
-        // we could load it. However, the user said "always checked once opened".
-        // To be safe and follow the request literally, we can just let it default to true.
-        // setLiteMode(JSON.parse(savedLiteMode)); 
-      }
     } catch (error) {
       console.error("Failed to parse honors data from localStorage", error);
     }
@@ -138,12 +196,10 @@ export default function HonorsCalcu() {
     return () => { if (persistTimerRef.current) clearTimeout(persistTimerRef.current); };
   }, [termsData]);
 
-  // Persist lite data
   React.useEffect(() => {
     localStorage.setItem("honorsLiteData", JSON.stringify(liteData));
   }, [liteData]);
 
-  // Persist lite mode toggle
   React.useEffect(() => {
     localStorage.setItem("honorsLiteMode", JSON.stringify(liteMode));
   }, [liteMode]);
@@ -158,6 +214,52 @@ export default function HonorsCalcu() {
       [year]: { ...prev[year], [field]: value },
     }));
   }, []);
+
+  /**
+   * Keyboard navigation grid (visual):
+   *
+   *           Term 1          Term 2          Term 3
+   *  Grade  [grade-1]  ←→  [grade-2]  ←→  [grade-3]
+   *                ↕                  ↕                  ↕
+   *  Units  [units-1]  ←→  [units-2]  ←→  [units-3]
+   *
+   *  ArrowLeft  → same field type, previous term column
+   *  ArrowRight → same field type, next term column
+   *  ArrowUp    → units → grade, same term column
+   *  ArrowDown  → grade → units, same term column
+   */
+  const handleLiteKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    type: "grade" | "units",
+    termNum: number,
+    yearKey: string
+  ) => {
+    const keys = ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"];
+    if (!keys.includes(e.key)) return;
+
+    e.preventDefault();
+
+    let nextId = "";
+
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      if (type === "grade") {
+        nextId = `lite-${yearKey}-units-${termNum}`;
+      } else if (termNum < 3) {
+        nextId = `lite-${yearKey}-grade-${termNum + 1}`;
+      }
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      if (type === "units") {
+        nextId = `lite-${yearKey}-grade-${termNum}`;
+      } else if (termNum > 1) {
+        nextId = `lite-${yearKey}-units-${termNum - 1}`;
+      }
+    }
+
+    if (nextId) {
+      const el = document.getElementById(nextId) as HTMLInputElement;
+      if (el) { el.focus(); el.select(); }
+    }
+  };
 
   const tableLayout = React.useMemo(() => [
     ["Year 1 Term 1", "Year 1 Term 2", "Year 1 Term 3"],
@@ -241,7 +343,7 @@ export default function HonorsCalcu() {
   }, [termsData]);
 
   const liteStats = React.useMemo(() => {
-    const stats: Record<string, { gpa: number; eligible: string }> = {};
+    const stats: Record<string, { gpa: number; eligible: string; totalUnits: number }> = {};
     Object.entries(liteData).forEach(([year, data]) => {
       stats[year] = calcLiteStats(data);
     });
@@ -297,7 +399,7 @@ export default function HonorsCalcu() {
             </AnimatePresence>
           </p>
 
-          {/* ── Lite Mode Toggle ── placed right below the subtitle, centered */}
+          {/* Lite Mode Toggle */}
           <div className="flex items-center justify-center gap-2.5 mt-6">
             <button
               role="checkbox"
@@ -337,7 +439,6 @@ export default function HonorsCalcu() {
 
         <hr className="mb-10 border-border/100" />
 
-        {/* Year Sections */}
         <div className="space-y-12">
           {(liteMode ? [1] : [1, 2, 3, 4]).map((yearNum) => {
             const yearKey = `Year ${yearNum}`;
@@ -355,7 +456,7 @@ export default function HonorsCalcu() {
 
                 <AnimatePresence mode="wait">
                   {liteMode ? (
-                    /* ── Lite Mode: 3 term average inputs ── */
+                    /* Lite Mode: 3 term inputs (grade + units inline) */
                     <motion.div
                       key="lite-view"
                       initial={{ opacity: 0, x: 20 }}
@@ -368,30 +469,24 @@ export default function HonorsCalcu() {
                         <p className="text-sm font-medium text-foreground mb-5">
                           General Average per Term
                         </p>
-                        <div className="flex flex-wrap gap-6">
-                          <LiteInput
-                            id={`lite-${yearKey}-t1`}
-                            label="Term 1"
-                            value={liteData[yearKey]?.term1 ?? ""}
-                            onChange={v => handleLiteChange(yearKey, "term1", v)}
-                          />
-                          <LiteInput
-                            id={`lite-${yearKey}-t2`}
-                            label="Term 2"
-                            value={liteData[yearKey]?.term2 ?? ""}
-                            onChange={v => handleLiteChange(yearKey, "term2", v)}
-                          />
-                          <LiteInput
-                            id={`lite-${yearKey}-t3`}
-                            label="Term 3"
-                            value={liteData[yearKey]?.term3 ?? ""}
-                            onChange={v => handleLiteChange(yearKey, "term3", v)}
-                          />
+                        <div className="grid grid-cols-3 gap-4">
+                          {[1, 2, 3].map(num => (
+                            <LiteTermRow
+                              key={num}
+                              termNum={num}
+                              yearKey={yearKey}
+                              gradeValue={liteData[yearKey]?.[`term${num}` as keyof LiteYearData] || ""}
+                              unitsValue={liteData[yearKey]?.[`units${num}` as keyof LiteYearData] || ""}
+                              onGradeChange={v => handleLiteChange(yearKey, `term${num}` as keyof LiteYearData, v)}
+                              onUnitsChange={v => handleLiteChange(yearKey, `units${num}` as keyof LiteYearData, v)}
+                              onKeyDown={handleLiteKeyDown}
+                            />
+                          ))}
                         </div>
                       </div>
                     </motion.div>
                   ) : (
-                    /* ── Full Mode: term tables ── */
+                    /* Full Mode: term tables */
                     <motion.div
                       key="full-view"
                       initial={{ opacity: 0, x: -20 }}
@@ -431,7 +526,7 @@ export default function HonorsCalcu() {
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -10 }}
-                        className="flex gap-4"
+                        className="flex gap-4 flex-wrap justify-center"
                       >
                         <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
                           <p className="text-sm text-muted-foreground mb-1">Average GPA</p>
@@ -439,6 +534,12 @@ export default function HonorsCalcu() {
                             {liteStats[yearKey]?.gpa > 0
                               ? liteStats[yearKey].gpa.toFixed(2)
                               : "0.00"}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                          <p className="text-sm text-muted-foreground mb-1">Total Units</p>
+                          <p className="text-2xl font-bold text-foreground">
+                            {liteStats[yearKey]?.totalUnits ?? "0"}
                           </p>
                         </div>
                         <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -399,7 +399,7 @@ export default function HonorsCalcu() {
                 transition={{ duration: 0.2 }}
               >
                 {liteMode ? (
-                  <>Enter your general average for each term per academic year</>
+                  <>Enter your general average for a school year</>
                 ) : (
                   <>
                     Enter subjects and grades for each term per academic year <br />

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -34,7 +34,7 @@ interface LiteYearData {
   units3: string;
 }
 
-function calcLiteStats(data: LiteYearData): { gpa: number; eligible: string; totalUnits: number } {
+function calcLiteStats(data: LiteYearData, showUnits: boolean): { gpa: number; eligible: string; totalUnits: number } {
   const t1 = parseFloat(data.term1);
   const t2 = parseFloat(data.term2);
   const t3 = parseFloat(data.term3);
@@ -51,7 +51,7 @@ function calcLiteStats(data: LiteYearData): { gpa: number; eligible: string; tot
 
   let eligible: string;
   if (avg >= 3.0 && avg <= 4.0) {
-    if (totalUnits >= 36) eligible = "Yes";
+    if (!showUnits || totalUnits >= 36) eligible = "Yes";
     else eligible = "No, not enough units (need 36)";
   } else {
     eligible = "No";
@@ -69,6 +69,7 @@ function LiteTermRow({
   onGradeChange,
   onUnitsChange,
   onKeyDown,
+  showUnits,
 }: {
   termNum: number;
   yearKey: string;
@@ -82,6 +83,7 @@ function LiteTermRow({
     termNum: number,
     yearKey: string
   ) => void;
+  showUnits: boolean;
 }) {
   return (
     <div className="flex flex-col gap-1.5">
@@ -121,31 +123,40 @@ function LiteTermRow({
         </div>
 
         {/* Units — narrow pill */}
-        <div className="flex flex-col gap-1 w-14">
-          <label
-            htmlFor={`lite-${yearKey}-units-${termNum}`}
-            className="text-xs text-muted-foreground font-medium"
-          >
-            Units
-          </label>
-          <input
-            id={`lite-${yearKey}-units-${termNum}`}
-            type="number"
-            step="1"
-            min="0"
-            value={unitsValue}
-            onChange={e => onUnitsChange(e.target.value)}
-            onKeyDown={e => onKeyDown(e, "units", termNum, yearKey)}
-            placeholder="0"
-            className="
-              w-full rounded-md border border-input bg-background px-2 py-1.5
-              text-sm text-center text-foreground shadow-sm
-              placeholder:text-muted-foreground/50
-              focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
-              transition-colors
-            "
-          />
-        </div>
+        <AnimatePresence>
+          {showUnits && (
+            <motion.div
+              initial={{ opacity: 0, width: 0, x: 10 }}
+              animate={{ opacity: 1, width: 56, x: 0 }}
+              exit={{ opacity: 0, width: 0, x: 10 }}
+              className="flex flex-col gap-1 overflow-hidden"
+            >
+              <label
+                htmlFor={`lite-${yearKey}-units-${termNum}`}
+                className="text-xs text-muted-foreground font-medium whitespace-nowrap"
+              >
+                Units
+              </label>
+              <input
+                id={`lite-${yearKey}-units-${termNum}`}
+                type="number"
+                step="1"
+                min="0"
+                value={unitsValue}
+                onChange={e => onUnitsChange(e.target.value)}
+                onKeyDown={e => onKeyDown(e, "units", termNum, yearKey)}
+                placeholder="0"
+                className="
+                  w-full rounded-md border border-input bg-background px-2 py-1.5
+                  text-sm text-center text-foreground shadow-sm
+                  placeholder:text-muted-foreground/50
+                  focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+                  transition-colors
+                "
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   );
@@ -154,6 +165,7 @@ function LiteTermRow({
 export default function HonorsCalcu() {
   const [termsData, setTermsData] = React.useState<Record<string, RowData[]>>({});
   const [liteMode, setLiteMode] = React.useState(true);
+  const [showUnits, setShowUnits] = React.useState(false);
   const [liteData, setLiteData] = React.useState<Record<string, LiteYearData>>({
     "Year 1": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
     "Year 2": { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
@@ -345,10 +357,10 @@ export default function HonorsCalcu() {
   const liteStats = React.useMemo(() => {
     const stats: Record<string, { gpa: number; eligible: string; totalUnits: number }> = {};
     Object.entries(liteData).forEach(([year, data]) => {
-      stats[year] = calcLiteStats(data);
+      stats[year] = calcLiteStats(data, showUnits);
     });
     return stats;
-  }, [liteData]);
+  }, [liteData, showUnits]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -466,9 +478,23 @@ export default function HonorsCalcu() {
                       className="flex justify-center"
                     >
                       <div className="rounded-lg border bg-card p-6 shadow-sm w-full max-w-lg">
-                        <p className="text-sm font-medium text-foreground mb-5">
-                          General Average per Term
-                        </p>
+                        <div className="flex items-center justify-between mb-5">
+                          <p className="text-sm font-medium text-foreground">
+                            General Average per Term
+                          </p>
+                          <div className="flex items-center gap-2">
+                            <label htmlFor="show-units-toggle" className="text-xs text-muted-foreground cursor-pointer select-none">
+                              Include Units?
+                            </label>
+                            <input
+                              id="show-units-toggle"
+                              type="checkbox"
+                              checked={showUnits}
+                              onChange={e => setShowUnits(e.target.checked)}
+                              className="w-3.5 h-3.5 rounded border-input text-foreground focus:ring-ring cursor-pointer"
+                            />
+                          </div>
+                        </div>
                         <div className="grid grid-cols-3 gap-4">
                           {[1, 2, 3].map(num => (
                             <LiteTermRow
@@ -480,6 +506,7 @@ export default function HonorsCalcu() {
                               onGradeChange={v => handleLiteChange(yearKey, `term${num}` as keyof LiteYearData, v)}
                               onUnitsChange={v => handleLiteChange(yearKey, `units${num}` as keyof LiteYearData, v)}
                               onKeyDown={handleLiteKeyDown}
+                              showUnits={showUnits}
                             />
                           ))}
                         </div>
@@ -522,32 +549,50 @@ export default function HonorsCalcu() {
                   <AnimatePresence mode="wait">
                     {liteMode ? (
                       <motion.div
+                        layout
                         key="lite-stats"
                         initial={{ opacity: 0, y: 10 }}
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -10 }}
-                        className="flex gap-4 flex-wrap justify-center"
+                        className="flex gap-4 flex-wrap justify-center items-center"
                       >
-                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                        <motion.div
+                          layout
+                          className="rounded-lg border bg-card px-6 py-4 shadow-sm"
+                        >
                           <p className="text-sm text-muted-foreground mb-1">Average GPA</p>
                           <p className="text-2xl font-bold text-foreground">
                             {liteStats[yearKey]?.gpa > 0
                               ? liteStats[yearKey].gpa.toFixed(2)
                               : "0.00"}
                           </p>
-                        </div>
-                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
-                          <p className="text-sm text-muted-foreground mb-1">Total Units</p>
-                          <p className="text-2xl font-bold text-foreground">
-                            {liteStats[yearKey]?.totalUnits ?? "0"}
-                          </p>
-                        </div>
-                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                        </motion.div>
+                        <AnimatePresence mode="popLayout">
+                          {showUnits && (
+                            <motion.div
+                              layout
+                              initial={{ opacity: 0, scale: 0.8 }}
+                              animate={{ opacity: 1, scale: 1 }}
+                              exit={{ opacity: 0, scale: 0.8 }}
+                              transition={{ duration: 0.3 }}
+                              className="rounded-lg border bg-card px-6 py-4 shadow-sm"
+                            >
+                              <p className="text-sm text-muted-foreground mb-1">Total Units</p>
+                              <p className="text-2xl font-bold text-foreground">
+                                {liteStats[yearKey]?.totalUnits ?? "0"}
+                              </p>
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                        <motion.div
+                          layout
+                          className="rounded-lg border bg-card px-6 py-4 shadow-sm"
+                        >
                           <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
                           <p className="text-2xl font-bold text-foreground">
                             {liteStats[yearKey]?.eligible ?? "-"}
                           </p>
-                        </div>
+                        </motion.div>
                       </motion.div>
                     ) : (
                       yearStats[yearKey] && (

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -1,10 +1,11 @@
 "use client"
 import * as React from 'react';
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calculator } from "lucide-react";
+import { ArrowLeft, Calculator, Zap } from "lucide-react";
 import { TermTable } from '../../components/TermTable';
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { motion, AnimatePresence } from "framer-motion";
 
 // Memoized TermTable to prevent unnecessary re-renders
 const MemoizedTermTable = React.memo(TermTable);
@@ -23,8 +24,77 @@ interface YearStats {
   eligible: string;
 }
 
+// Lite Mode: per-year general averages (3 terms each)
+interface LiteYearData {
+  term1: string;
+  term2: string;
+  term3: string;
+}
+
+function calcLiteStats(data: LiteYearData): { gpa: number; eligible: string } {
+  const t1 = parseFloat(data.term1);
+  const t2 = parseFloat(data.term2);
+  const t3 = parseFloat(data.term3);
+
+  const values = [t1, t2, t3].filter(v => !isNaN(v) && v > 0);
+  if (values.length === 0) return { gpa: 0, eligible: '-' };
+
+  const avg = values.reduce((a, b) => a + b, 0) / values.length;
+
+  // Same honors criteria as full mode — GPA between 3.0 and 4.0
+  let eligible: string;
+  if (avg >= 3.0 && avg <= 4.0) eligible = "Yes";
+  else eligible = "No";
+
+  return { gpa: avg, eligible };
+}
+
+// Shared input style matching TermTable inputs
+function LiteInput({
+  label,
+  value,
+  onChange,
+  id,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  id: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs text-muted-foreground font-medium">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        step="0.01"
+        min="0"
+        max="5"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="0.00"
+        className="
+          w-28 rounded-md border border-input bg-background px-3 py-1.5
+          text-sm text-foreground shadow-sm
+          placeholder:text-muted-foreground/50
+          focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+          transition-colors
+        "
+      />
+    </div>
+  );
+}
 export default function HonorsCalcu() {
   const [termsData, setTermsData] = React.useState<Record<string, RowData[]>>({});
+  const [liteMode, setLiteMode] = React.useState(true);
+  const [liteData, setLiteData] = React.useState<Record<string, LiteYearData>>({
+    "Year 1": { term1: "", term2: "", term3: "" },
+    "Year 2": { term1: "", term2: "", term3: "" },
+    "Year 3": { term1: "", term2: "", term3: "" },
+    "Year 4": { term1: "", term2: "", term3: "" },
+  });
 
   const termsDataRef = React.useRef(termsData);
   termsDataRef.current = termsData;
@@ -39,36 +109,56 @@ export default function HonorsCalcu() {
           setTermsData(parsedData);
         }
       }
+      const savedLite = localStorage.getItem("honorsLiteData");
+      if (savedLite) {
+        const parsedLite = JSON.parse(savedLite);
+        if (typeof parsedLite === 'object' && parsedLite !== null) {
+          setLiteData(parsedLite);
+        }
+      }
+      const savedLiteMode = localStorage.getItem("honorsLiteMode");
+      if (savedLiteMode !== null) {
+        // We set it to true by default, but if they explicitly changed it in this session,
+        // we could load it. However, the user said "always checked once opened".
+        // To be safe and follow the request literally, we can just let it default to true.
+        // setLiteMode(JSON.parse(savedLiteMode)); 
+      }
     } catch (error) {
-      console.error("Failed to parse honorsTermsData from localStorage", error);
+      console.error("Failed to parse honors data from localStorage", error);
     }
   }, []);
 
-  // Persist on change - debounced to avoid excessive localStorage writes
+  // Persist full mode data
   const persistTimerRef = React.useRef<NodeJS.Timeout | null>(null);
   React.useEffect(() => {
-    if (persistTimerRef.current) {
-      clearTimeout(persistTimerRef.current);
-    }
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
     persistTimerRef.current = setTimeout(() => {
       localStorage.setItem("honorsTermsData", JSON.stringify(termsData));
     }, 300);
-
-    return () => {
-      if (persistTimerRef.current) {
-        clearTimeout(persistTimerRef.current);
-      }
-    };
+    return () => { if (persistTimerRef.current) clearTimeout(persistTimerRef.current); };
   }, [termsData]);
 
+  // Persist lite data
+  React.useEffect(() => {
+    localStorage.setItem("honorsLiteData", JSON.stringify(liteData));
+  }, [liteData]);
+
+  // Persist lite mode toggle
+  React.useEffect(() => {
+    localStorage.setItem("honorsLiteMode", JSON.stringify(liteMode));
+  }, [liteMode]);
+
   const handleTermChange = React.useCallback((term: string, rows: RowData[]) => {
-    setTermsData(prev => ({
+    setTermsData(prev => ({ ...prev, [term]: rows }));
+  }, []);
+
+  const handleLiteChange = React.useCallback((year: string, field: keyof LiteYearData, value: string) => {
+    setLiteData(prev => ({
       ...prev,
-      [term]: rows
+      [year]: { ...prev[year], [field]: value },
     }));
   }, []);
 
-  // 4x3 layout for Year 1–4 - memoized to prevent recreation
   const tableLayout = React.useMemo(() => [
     ["Year 1 Term 1", "Year 1 Term 2", "Year 1 Term 3"],
     ["Year 2 Term 1", "Year 2 Term 2", "Year 2 Term 3"],
@@ -76,7 +166,6 @@ export default function HonorsCalcu() {
     ["Year 4 Term 1", "Year 4 Term 2", "Year 4 Term 3"],
   ], []);
 
-  // Arrow-key navigation between tables
   const handleEdge = (
     direction: "up" | "down" | "left" | "right",
     fromTerm: string,
@@ -92,59 +181,35 @@ export default function HonorsCalcu() {
     let nextCellCol = fromCol;
 
     if (direction === "left" && fromCol === 0) {
-      if (termColIndex > 0) {
-        nextTermName = tableLayout[termRowIndex][termColIndex - 1];
-        nextCellCol = 2; // Last editable column
-      }
+      if (termColIndex > 0) { nextTermName = tableLayout[termRowIndex][termColIndex - 1]; nextCellCol = 2; }
     } else if (direction === "right" && fromCol === 2) {
-      if (termColIndex < tableLayout[termRowIndex].length - 1) {
-        nextTermName = tableLayout[termRowIndex][termColIndex + 1];
-        nextCellCol = 0; // First column
-      }
+      if (termColIndex < tableLayout[termRowIndex].length - 1) { nextTermName = tableLayout[termRowIndex][termColIndex + 1]; nextCellCol = 0; }
     } else if (direction === "up" && fromRow === 0) {
-      if (termRowIndex > 0) {
-        nextTermName = tableLayout[termRowIndex - 1][termColIndex];
-        const targetRows = termsData[nextTermName] || [];
-        nextCellRow = Math.max(0, targetRows.length - 1);
-      }
+      if (termRowIndex > 0) { nextTermName = tableLayout[termRowIndex - 1][termColIndex]; const targetRows = termsData[nextTermName] || []; nextCellRow = Math.max(0, targetRows.length - 1); }
     } else if (direction === "down" && fromRow === (termsData[fromTerm]?.length || 0) - 1) {
-      if (termRowIndex < tableLayout.length - 1) {
-        nextTermName = tableLayout[termRowIndex + 1][termColIndex];
-        nextCellRow = 0;
-      }
+      if (termRowIndex < tableLayout.length - 1) { nextTermName = tableLayout[termRowIndex + 1][termColIndex]; nextCellRow = 0; }
     }
 
     if (nextTermName) {
       const nextTermRows = termsData[nextTermName] || [];
-      if (nextTermRows.length > 0 && nextCellRow >= nextTermRows.length) {
-        nextCellRow = nextTermRows.length - 1;
-      }
-      if (nextCellRow < 0 || nextTermRows.length === 0) {
-        nextCellRow = 0;
-      }
-
+      if (nextTermRows.length > 0 && nextCellRow >= nextTermRows.length) nextCellRow = nextTermRows.length - 1;
+      if (nextCellRow < 0 || nextTermRows.length === 0) nextCellRow = 0;
       const nextCellId = `cell-${nextTermName}-${nextCellRow}-${nextCellCol}`;
       const targetInput = document.getElementById(nextCellId) as HTMLInputElement;
-      if (targetInput) {
-        targetInput.focus();
-        targetInput.select();
-      }
+      if (targetInput) { targetInput.focus(); targetInput.select(); }
     }
   };
 
-  // Recompute per-year GPA and eligibility whenever termsData changes
-  // Memoize to avoid recalculating if termsData object reference didn't change
   const yearStats = React.useMemo(() => {
     const groupedByYear: Record<string, RowData[][]> = {};
     Object.entries(termsData).forEach(([term, rows]) => {
       if (!Array.isArray(rows)) return;
-      const year = term.split(' ').slice(0, 2).join(' '); // "Year X"
+      const year = term.split(' ').slice(0, 2).join(' ');
       if (!groupedByYear[year]) groupedByYear[year] = [];
       groupedByYear[year].push(rows);
     });
 
     const nextYearStats: Record<string, YearStats> = {};
-
     Object.entries(groupedByYear).forEach(([year, termRows]) => {
       const all = termRows.flat();
       const valid = all.filter(row => {
@@ -154,17 +219,13 @@ export default function HonorsCalcu() {
         return row.subjectCode.trim() !== '' && row.grade.trim() !== '' && row.unit > 0;
       });
 
-      if (valid.length === 0) {
-        nextYearStats[year] = { gpa: 0, totalUnits: 0, rGrades: 0, eligible: '-' };
-        return;
-      }
+      if (valid.length === 0) { nextYearStats[year] = { gpa: 0, totalUnits: 0, rGrades: 0, eligible: '-' }; return; }
 
       const totalHonorPoints = valid.reduce((sum, r) => sum + r.honorPoints, 0);
       const totalUnits = valid.reduce((sum, r) => sum + Number(r.unit), 0);
       const gpa = totalUnits > 0 ? totalHonorPoints / totalUnits : 0;
       const rGrades = valid.filter(r => (r.grade || '').toUpperCase() === 'R').length;
 
-      // Honors (per-year) criteria: >=36 units, <=2 R grades, GPA between 3.0 and 4.0
       const hasEnoughUnits = totalUnits >= 36;
       const hasTooManyRs = rGrades > 2;
       let eligible: string;
@@ -178,6 +239,14 @@ export default function HonorsCalcu() {
 
     return nextYearStats;
   }, [termsData]);
+
+  const liteStats = React.useMemo(() => {
+    const stats: Record<string, { gpa: number; eligible: string }> = {};
+    Object.entries(liteData).forEach(([year, data]) => {
+      stats[year] = calcLiteStats(data);
+    });
+    return stats;
+  }, [liteData]);
 
   return (
     <div className="min-h-screen bg-background">
@@ -198,9 +267,8 @@ export default function HonorsCalcu() {
         </div>
       </header>
 
-
-  {/* Main Content */}
-  <main className="container mx-auto px-4 py-16">
+      {/* Main Content */}
+      <main className="container mx-auto px-4 py-16">
         {/* Hero Section */}
         <div className="text-center mb-10">
           <div className="flex justify-center mb-4">
@@ -208,59 +276,210 @@ export default function HonorsCalcu() {
           </div>
           <h1 className="text-4xl font-normal text-foreground mb-4">Honors Calculator</h1>
           <p className="text-muted-foreground text-lg">
-            Enter subjects and grades for each term per academic year <br />
-            You can just use the arrow keys on your keyboard for easier navigation ^^ <br />
-            (Click on an input box first then you can use the arrow keys!)
+            <AnimatePresence mode="wait">
+              <motion.span
+                key={liteMode ? "lite" : "full"}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.2 }}
+              >
+                {liteMode ? (
+                  <>Enter your general average for each term per academic year</>
+                ) : (
+                  <>
+                    Enter subjects and grades for each term per academic year <br />
+                    You can just use the arrow keys on your keyboard for easier navigation ^^ <br />
+                    (Click on an input box first then you can use the arrow keys!)
+                  </>
+                )}
+              </motion.span>
+            </AnimatePresence>
           </p>
+
+          {/* ── Lite Mode Toggle ── placed right below the subtitle, centered */}
+          <div className="flex items-center justify-center gap-2.5 mt-6">
+            <button
+              role="checkbox"
+              aria-checked={liteMode}
+              onClick={() => setLiteMode(prev => !prev)}
+              className={`
+                relative inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center
+                rounded border-2 transition-colors duration-150
+                focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
+                ${liteMode
+                  ? 'bg-foreground border-foreground'
+                  : 'bg-background border-input hover:border-foreground/50'
+                }
+              `}
+            >
+              {liteMode && (
+                <svg
+                  className="h-3 w-3 text-background"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={3}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </button>
+            <label
+              onClick={() => setLiteMode(prev => !prev)}
+              className="flex items-center gap-1.5 text-sm text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors"
+            >
+              <Zap className="h-3.5 w-3.5" />
+              Lite Mode
+            </label>
+          </div>
         </div>
-  <hr className="mb-10 border-border/100" />
+
+        <hr className="mb-10 border-border/100" />
 
         {/* Year Sections */}
-        {[1,2,3,4].map((yearNum) => {
-          const yearKey = `Year ${yearNum}`;
-          return (
-            <React.Fragment key={yearKey}>
-              <section className="mt-12">
+        <div className="space-y-12">
+          {(liteMode ? [1] : [1, 2, 3, 4]).map((yearNum) => {
+            const yearKey = `Year ${yearNum}`;
+            return (
+              <motion.section
+                key={yearKey}
+                layout
+                initial={{ opacity: 0, scale: 0.95 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.4, ease: "easeOut" }}
+                className="mt-12"
+              >
                 <h2 className="text-2xl font-semibold mb-6 text-center">{yearKey}</h2>
-                <div className="grid md:grid-cols-3 gap-4 justify-center">
-                  <MemoizedTermTable
-                    term={`${yearKey} Term 1`}
-                    initialRows={termsData[`${yearKey} Term 1`]}
-                    onStatsChange={handleTermChange}
-                    onEdge={handleEdge}
-                  />
-                  <MemoizedTermTable
-                    term={`${yearKey} Term 2`}
-                    initialRows={termsData[`${yearKey} Term 2`]}
-                    onStatsChange={handleTermChange}
-                    onEdge={handleEdge}
-                  />
-                  <MemoizedTermTable
-                    term={`${yearKey} Term 3`}
-                    initialRows={termsData[`${yearKey} Term 3`]}
-                    onStatsChange={handleTermChange}
-                    onEdge={handleEdge}
-                  />
-                </div>
+
+                <AnimatePresence mode="wait">
+                  {liteMode ? (
+                    /* ── Lite Mode: 3 term average inputs ── */
+                    <motion.div
+                      key="lite-view"
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: -20 }}
+                      transition={{ duration: 0.3 }}
+                      className="flex justify-center"
+                    >
+                      <div className="rounded-lg border bg-card p-6 shadow-sm w-full max-w-lg">
+                        <p className="text-sm font-medium text-foreground mb-5">
+                          General Average per Term
+                        </p>
+                        <div className="flex flex-wrap gap-6">
+                          <LiteInput
+                            id={`lite-${yearKey}-t1`}
+                            label="Term 1"
+                            value={liteData[yearKey]?.term1 ?? ""}
+                            onChange={v => handleLiteChange(yearKey, "term1", v)}
+                          />
+                          <LiteInput
+                            id={`lite-${yearKey}-t2`}
+                            label="Term 2"
+                            value={liteData[yearKey]?.term2 ?? ""}
+                            onChange={v => handleLiteChange(yearKey, "term2", v)}
+                          />
+                          <LiteInput
+                            id={`lite-${yearKey}-t3`}
+                            label="Term 3"
+                            value={liteData[yearKey]?.term3 ?? ""}
+                            onChange={v => handleLiteChange(yearKey, "term3", v)}
+                          />
+                        </div>
+                      </div>
+                    </motion.div>
+                  ) : (
+                    /* ── Full Mode: term tables ── */
+                    <motion.div
+                      key="full-view"
+                      initial={{ opacity: 0, x: -20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: 20 }}
+                      transition={{ duration: 0.3 }}
+                      className="grid md:grid-cols-3 gap-4 justify-center"
+                    >
+                      <MemoizedTermTable
+                        term={`${yearKey} Term 1`}
+                        initialRows={termsData[`${yearKey} Term 1`]}
+                        onStatsChange={handleTermChange}
+                        onEdge={handleEdge}
+                      />
+                      <MemoizedTermTable
+                        term={`${yearKey} Term 2`}
+                        initialRows={termsData[`${yearKey} Term 2`]}
+                        onStatsChange={handleTermChange}
+                        onEdge={handleEdge}
+                      />
+                      <MemoizedTermTable
+                        term={`${yearKey} Term 3`}
+                        initialRows={termsData[`${yearKey} Term 3`]}
+                        onStatsChange={handleTermChange}
+                        onEdge={handleEdge}
+                      />
+                    </motion.div>
+                  )}
+                </AnimatePresence>
 
                 {/* Year Summary */}
-                {yearStats[yearKey] && (
-                  <div className="flex justify-center mt-6 gap-4">
-                    <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
-                      <p className="text-sm text-muted-foreground mb-1">Current GPA</p>
-                      <p className="text-2xl font-bold text-foreground">{yearStats[yearKey].gpa.toFixed(2)}</p>
-                    </div>
-                    <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
-                      <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
-                      <p className="text-2xl font-bold text-foreground">{yearStats[yearKey].eligible}</p>
-                    </div>
-                  </div>
-                )}
-              </section>
-              {yearNum < 4 && <hr className="my-12 border-border/100" />}
-            </React.Fragment>
-          );
-        })}
+                <div className="flex justify-center mt-6 gap-4">
+                  <AnimatePresence mode="wait">
+                    {liteMode ? (
+                      <motion.div
+                        key="lite-stats"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        className="flex gap-4"
+                      >
+                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                          <p className="text-sm text-muted-foreground mb-1">Average GPA</p>
+                          <p className="text-2xl font-bold text-foreground">
+                            {liteStats[yearKey]?.gpa > 0
+                              ? liteStats[yearKey].gpa.toFixed(2)
+                              : "0.00"}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                          <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
+                          <p className="text-2xl font-bold text-foreground">
+                            {liteStats[yearKey]?.eligible ?? "-"}
+                          </p>
+                        </div>
+                      </motion.div>
+                    ) : (
+                      yearStats[yearKey] && (
+                        <motion.div
+                          key="full-stats"
+                          initial={{ opacity: 0, y: 10 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: -10 }}
+                          className="flex gap-4"
+                        >
+                          <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                            <p className="text-sm text-muted-foreground mb-1">Current GPA</p>
+                            <p className="text-2xl font-bold text-foreground">
+                              {yearStats[yearKey].gpa.toFixed(2)}
+                            </p>
+                          </div>
+                          <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
+                            <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
+                            <p className="text-2xl font-bold text-foreground">
+                              {yearStats[yearKey].eligible}
+                            </p>
+                          </div>
+                        </motion.div>
+                      )
+                    )}
+                  </AnimatePresence>
+                </div>
+
+                {yearNum < (liteMode ? 1 : 4) && <hr className="my-12 border-border/100" />}
+              </motion.section>
+            );
+          })}
+        </div>
 
         {/* Footer */}
         <footer className="border-t pt-8 mt-16">

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -193,6 +193,8 @@ export default function HonorsCalcu() {
           setLiteData(parsedLite);
         }
       }
+      const savedLiteMode = localStorage.getItem("honorsLiteMode");
+      if (savedLiteMode !== null) setLiteMode(JSON.parse(savedLiteMode));
     } catch (error) {
       console.error("Failed to parse honors data from localStorage", error);
     }
@@ -227,19 +229,6 @@ export default function HonorsCalcu() {
     }));
   }, []);
 
-  /**
-   * Keyboard navigation grid (visual):
-   *
-   *           Term 1          Term 2          Term 3
-   *  Grade  [grade-1]  ←→  [grade-2]  ←→  [grade-3]
-   *                ↕                  ↕                  ↕
-   *  Units  [units-1]  ←→  [units-2]  ←→  [units-3]
-   *
-   *  ArrowLeft  → same field type, previous term column
-   *  ArrowRight → same field type, next term column
-   *  ArrowUp    → units → grade, same term column
-   *  ArrowDown  → grade → units, same term column
-   */
   const handleLiteKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
     type: "grade" | "units",
@@ -343,7 +332,7 @@ export default function HonorsCalcu() {
       const hasEnoughUnits = totalUnits >= 36;
       const hasTooManyRs = rGrades > 2;
       let eligible: string;
-      if (!hasEnoughUnits) eligible = "No, not enough units";
+      if (!hasEnoughUnits) eligible = "No, not enough units (need 36)";
       else if (hasTooManyRs) eligible = "No, more than 2 R grades";
       else if (gpa >= 3.0 && gpa <= 4.0) eligible = "Yes";
       else eligible = "No";
@@ -516,6 +505,12 @@ export default function HonorsCalcu() {
                       {yearStats[topSummaryYearKey].gpa.toFixed(2)}
                     </p>
                   </div>
+                  <div className="flex flex-col items-center px-8 py-2 border-r border-border/50">
+                    <p className="text-sm text-muted-foreground mb-1">Total Units</p>
+                    <p className="text-3xl font-bold tracking-tight text-foreground">
+                      {yearStats[topSummaryYearKey].totalUnits}
+                    </p>
+                  </div>
                   <div className="flex flex-col items-center px-8 py-2">
                     <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
                     <p className="text-3xl font-bold tracking-tight text-primary">
@@ -527,7 +522,6 @@ export default function HonorsCalcu() {
             )}
           </AnimatePresence>
         </div>
-
 
         <hr className="mb-10 border-border/100" />
 
@@ -623,8 +617,6 @@ export default function HonorsCalcu() {
                     </motion.div>
                   )}
                 </AnimatePresence>
-
-                
 
                 {yearNum < (liteMode ? 1 : 4) && <hr className="my-12 border-border/100" />}
               </motion.section>

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -362,6 +362,8 @@ export default function HonorsCalcu() {
     return stats;
   }, [liteData, showUnits]);
 
+  const topSummaryYearKey = "Year 1";
+
   return (
     <div className="min-h-screen bg-background">
       {/* Header */}
@@ -448,6 +450,84 @@ export default function HonorsCalcu() {
             </label>
           </div>
         </div>
+
+        {/* Year Summary */}
+        <div className="flex justify-center mb-10">
+          <AnimatePresence mode="wait">
+            {liteMode ? (
+              <motion.div
+                layout
+                key="lite-stats"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                className="flex gap-0 flex-wrap justify-center items-center p-6 rounded-xl border bg-card/50 shadow-sm"
+              >
+                <motion.div
+                  layout
+                  className="flex flex-col items-center px-8 py-2 border-r border-border/50 last:border-0"
+                >
+                  <p className="text-sm text-muted-foreground mb-1">Average GPA</p>
+                  <p className="text-3xl font-bold tracking-tight text-foreground">
+                    {liteStats[topSummaryYearKey]?.gpa > 0
+                      ? liteStats[topSummaryYearKey].gpa.toFixed(2)
+                      : "0.00"}
+                  </p>
+                </motion.div>
+                <AnimatePresence mode="popLayout">
+                  {showUnits && (
+                    <motion.div
+                      layout
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.8 }}
+                      transition={{ duration: 0.3 }}
+                      className="flex flex-col items-center px-8 py-2 border-r border-border/50 last:border-0"
+                    >
+                      <p className="text-sm text-muted-foreground mb-1">Total Units</p>
+                      <p className="text-3xl font-bold tracking-tight text-foreground">
+                        {liteStats[topSummaryYearKey]?.totalUnits ?? "0"}
+                      </p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+                <motion.div
+                  layout
+                  className="flex flex-col items-center px-8 py-2"
+                >
+                  <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
+                  <p className="text-3xl font-bold tracking-tight text-primary">
+                    {liteStats[topSummaryYearKey]?.eligible ?? "-"}
+                  </p>
+                </motion.div>
+              </motion.div>
+            ) : (
+              yearStats[topSummaryYearKey] && (
+                <motion.div
+                  key="full-stats"
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -10 }}
+                  className="flex gap-0 flex-wrap justify-center items-center p-6 rounded-xl border bg-card/50 shadow-sm"
+                >
+                  <div className="flex flex-col items-center px-8 py-2 border-r border-border/50">
+                    <p className="text-sm text-muted-foreground mb-1">Current GPA</p>
+                    <p className="text-3xl font-bold tracking-tight text-foreground">
+                      {yearStats[topSummaryYearKey].gpa.toFixed(2)}
+                    </p>
+                  </div>
+                  <div className="flex flex-col items-center px-8 py-2">
+                    <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
+                    <p className="text-3xl font-bold tracking-tight text-primary">
+                      {yearStats[topSummaryYearKey].eligible}
+                    </p>
+                  </div>
+                </motion.div>
+              )
+            )}
+          </AnimatePresence>
+        </div>
+
 
         <hr className="mb-10 border-border/100" />
 
@@ -544,82 +624,7 @@ export default function HonorsCalcu() {
                   )}
                 </AnimatePresence>
 
-                {/* Year Summary */}
-                <div className="flex justify-center mt-6 gap-4">
-                  <AnimatePresence mode="wait">
-                    {liteMode ? (
-                      <motion.div
-                        layout
-                        key="lite-stats"
-                        initial={{ opacity: 0, y: 10 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -10 }}
-                        className="flex gap-4 flex-wrap justify-center items-center"
-                      >
-                        <motion.div
-                          layout
-                          className="rounded-lg border bg-card px-6 py-4 shadow-sm"
-                        >
-                          <p className="text-sm text-muted-foreground mb-1">Average GPA</p>
-                          <p className="text-2xl font-bold text-foreground">
-                            {liteStats[yearKey]?.gpa > 0
-                              ? liteStats[yearKey].gpa.toFixed(2)
-                              : "0.00"}
-                          </p>
-                        </motion.div>
-                        <AnimatePresence mode="popLayout">
-                          {showUnits && (
-                            <motion.div
-                              layout
-                              initial={{ opacity: 0, scale: 0.8 }}
-                              animate={{ opacity: 1, scale: 1 }}
-                              exit={{ opacity: 0, scale: 0.8 }}
-                              transition={{ duration: 0.3 }}
-                              className="rounded-lg border bg-card px-6 py-4 shadow-sm"
-                            >
-                              <p className="text-sm text-muted-foreground mb-1">Total Units</p>
-                              <p className="text-2xl font-bold text-foreground">
-                                {liteStats[yearKey]?.totalUnits ?? "0"}
-                              </p>
-                            </motion.div>
-                          )}
-                        </AnimatePresence>
-                        <motion.div
-                          layout
-                          className="rounded-lg border bg-card px-6 py-4 shadow-sm"
-                        >
-                          <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
-                          <p className="text-2xl font-bold text-foreground">
-                            {liteStats[yearKey]?.eligible ?? "-"}
-                          </p>
-                        </motion.div>
-                      </motion.div>
-                    ) : (
-                      yearStats[yearKey] && (
-                        <motion.div
-                          key="full-stats"
-                          initial={{ opacity: 0, y: 10 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={{ opacity: 0, y: -10 }}
-                          className="flex gap-4"
-                        >
-                          <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
-                            <p className="text-sm text-muted-foreground mb-1">Current GPA</p>
-                            <p className="text-2xl font-bold text-foreground">
-                              {yearStats[yearKey].gpa.toFixed(2)}
-                            </p>
-                          </div>
-                          <div className="rounded-lg border bg-card px-6 py-4 shadow-sm">
-                            <p className="text-sm text-muted-foreground mb-1">Eligible for Honors</p>
-                            <p className="text-2xl font-bold text-foreground">
-                              {yearStats[yearKey].eligible}
-                            </p>
-                          </div>
-                        </motion.div>
-                      )
-                    )}
-                  </AnimatePresence>
-                </div>
+                
 
                 {yearNum < (liteMode ? 1 : 4) && <hr className="my-12 border-border/100" />}
               </motion.section>

--- a/src/app/latin-honors/page.tsx
+++ b/src/app/latin-honors/page.tsx
@@ -289,12 +289,14 @@ export default function LatinHonorsCalculator() {
       if (allTermGPAs.length > 0) {
         if (showUnits && totalUnits < 144) {
           eligible = "No, not enough units (need 144)";
-        } else if (averageGPA >= 3.85) {
+        } else if (averageGPA >= 3.80) {
           eligible = "Summa Cum Laude";
-        } else if (averageGPA >= 3.70) {
+        } else if (averageGPA >= 3.60) {
           eligible = "Magna Cum Laude";
-        } else if (averageGPA >= 3.50) {
+        } else if (averageGPA >= 3.40) {
           eligible = "Cum Laude";
+        } else if (averageGPA >= 3.00) {
+          eligible = "Academic Distinction";
         } else {
           eligible = "No Latin Honor";
         }
@@ -333,9 +335,10 @@ export default function LatinHonorsCalculator() {
       if (yearGPAs.length > 0) {
         if (combinedUnits < 144) eligible = "No, not enough units (need 144)";
         else if (combinedRs > 8) eligible = "No, more than 8 R grades";
-        else if (averageGPA >= 3.85) eligible = "Summa Cum Laude";
-        else if (averageGPA >= 3.70) eligible = "Magna Cum Laude";
-        else if (averageGPA >= 3.50) eligible = "Cum Laude";
+        else if (averageGPA >= 3.80) eligible = "Summa Cum Laude";
+        else if (averageGPA >= 3.60) eligible = "Magna Cum Laude";
+        else if (averageGPA >= 3.40) eligible = "Cum Laude";
+        else if (averageGPA >= 3.00) eligible = "Academic Distinction";
         else eligible = "No Latin Honor";
       }
 
@@ -427,7 +430,7 @@ export default function LatinHonorsCalculator() {
             </AnimatePresence>
 
             <motion.div layout className="flex flex-col items-center px-8 py-2">
-              <p className="text-sm text-muted-foreground mb-1">Latin Honor Status</p>
+              <p className="text-sm text-muted-foreground mb-1">Academic Honor Status</p>
               <p className="text-3xl font-bold tracking-tight text-primary">{results.latinHonor}</p>
             </motion.div>
           </motion.div>

--- a/src/app/latin-honors/page.tsx
+++ b/src/app/latin-honors/page.tsx
@@ -1,10 +1,14 @@
 "use client"
 import * as React from 'react';
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Calculator } from "lucide-react";
+import { ArrowLeft, Calculator, Zap } from "lucide-react";
 import { TermTable } from '../../components/TermTable';
 import Link from "next/link";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { motion, AnimatePresence } from "framer-motion";
+
+// Memoized TermTable for full mode
+const MemoizedTermTable = React.memo(TermTable);
 
 interface RowData {
   subjectCode: string;
@@ -20,15 +24,121 @@ interface YearStats {
   rGrades: number;
 }
 
+interface LiteYearInput {
+  gpa: string;
+  units: string;
+}
+
+// ── Lite Mode row for Latin Honors (one year per row/cell) ──
+function LiteYearRow({
+  yearNum,
+  gradeValue,
+  unitsValue,
+  onGradeChange,
+  onUnitsChange,
+  onKeyDown,
+  showUnits,
+}: {
+  yearNum: number;
+  gradeValue: string;
+  unitsValue: string;
+  onGradeChange: (v: string) => void;
+  onUnitsChange: (v: string) => void;
+  onKeyDown: (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    type: "grade" | "units",
+    yearNum: number
+  ) => void;
+  showUnits: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        Year {yearNum}
+      </p>
+
+      <div className="flex items-end gap-2">
+        <div className="flex flex-col gap-1 flex-1">
+          <label
+            htmlFor={`lite-year-${yearNum}-grade`}
+            className="text-xs text-muted-foreground font-medium"
+          >
+            GPA
+          </label>
+          <input
+            id={`lite-year-${yearNum}-grade`}
+            type="number"
+            step="0.01"
+            min="0"
+            max="5"
+            value={gradeValue}
+            onChange={e => onGradeChange(e.target.value)}
+            onKeyDown={e => onKeyDown(e, "grade", yearNum)}
+            placeholder="0.00"
+            className="
+              w-full rounded-md border border-input bg-background px-3 py-1.5
+              text-sm text-foreground shadow-sm
+              placeholder:text-muted-foreground/50
+              focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+              transition-colors
+            "
+          />
+        </div>
+
+        <AnimatePresence mode="popLayout">
+          {showUnits && (
+            <motion.div
+              initial={{ opacity: 0, width: 0, x: 10 }}
+              animate={{ opacity: 1, width: 64, x: 0 }}
+              exit={{ opacity: 0, width: 0, x: 10 }}
+              className="flex flex-col gap-1 overflow-hidden"
+            >
+              <label
+                htmlFor={`lite-year-${yearNum}-units`}
+                className="text-xs text-muted-foreground font-medium whitespace-nowrap"
+              >
+                Units
+              </label>
+              <input
+                id={`lite-year-${yearNum}-units`}
+                type="number"
+                step="1"
+                min="0"
+                value={unitsValue}
+                onChange={e => onUnitsChange(e.target.value)}
+                onKeyDown={e => onKeyDown(e, "units", yearNum)}
+                placeholder="0"
+                className="
+                  w-full rounded-md border border-input bg-background px-2 py-1.5
+                  text-sm text-center text-foreground shadow-sm
+                  placeholder:text-muted-foreground/50
+                  focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
+                  transition-colors
+                "
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
 export default function LatinHonorsCalculator() {
   const [termsData, setTermsData] = React.useState<Record<string, RowData[]>>({});
-  const [yearStats, setYearStats] = React.useState<Record<string, YearStats>>({});
-  const [overallGPA, setOverallGPA] = React.useState("0.00");
-  const [latinHonor, setLatinHonor] = React.useState("-");
+  const [liteMode, setLiteMode] = React.useState(true);
+  const [showUnits, setShowUnits] = React.useState(false);
+  const [liteData, setLiteData] = React.useState<Record<number, LiteYearInput>>({
+    1: { gpa: "", units: "" },
+    2: { gpa: "", units: "" },
+    3: { gpa: "", units: "" },
+    4: { gpa: "", units: "" },
+  });
 
   const termsDataRef = React.useRef(termsData);
   termsDataRef.current = termsData;
 
+  // Load persisted data
   React.useEffect(() => {
     try {
       const savedData = localStorage.getItem("latinHonorsTermsData");
@@ -38,65 +148,73 @@ export default function LatinHonorsCalculator() {
           setTermsData(parsedData);
         }
       }
+      const savedLite = localStorage.getItem("latinHonorsLiteData");
+      if (savedLite) {
+        const parsedLite = JSON.parse(savedLite);
+        if (typeof parsedLite === 'object' && parsedLite !== null) {
+          setLiteData(parsedLite);
+        }
+      }
+      const savedLiteMode = localStorage.getItem("latinHonorsLiteMode");
+      if (savedLiteMode !== null) setLiteMode(JSON.parse(savedLiteMode));
     } catch (error) {
-      console.error("Failed to parse latinHonorsTermsData from localStorage", error);
+      console.error("Failed to parse latin honors data from localStorage", error);
     }
   }, []);
 
+  // Persist data
   React.useEffect(() => {
     localStorage.setItem("latinHonorsTermsData", JSON.stringify(termsData));
   }, [termsData]);
 
+  React.useEffect(() => {
+    localStorage.setItem("latinHonorsLiteData", JSON.stringify(liteData));
+  }, [liteData]);
+
+  React.useEffect(() => {
+    localStorage.setItem("latinHonorsLiteMode", JSON.stringify(liteMode));
+  }, [liteMode]);
+
   const handleTermChange = React.useCallback((term: string, rows: RowData[]) => {
-    setTermsData(prev => ({
-      ...prev,
-      [term]: rows
-    }));
+    setTermsData(prev => ({ ...prev, [term]: rows }));
   }, []);
 
-  // Calculate year statistics from term statistics
-  React.useEffect(() => {
-    const newYearStats: Record<string, YearStats> = {};
-    
-    // Group terms by year
-    const yearGroups: Record<string, RowData[][]> = {};
-    Object.entries(termsData).forEach(([term, rows]) => {
-      if (Array.isArray(rows)) {
-        const year = term.split(' ')[0]; // Extract year from term name (e.g., "Year 1 Term 1" -> "Year 1")
-        if (!yearGroups[year]) {
-          yearGroups[year] = [];
-        }
-        yearGroups[year].push(rows);
+  const handleLiteChange = (yearNum: number, field: keyof LiteYearInput, value: string) => {
+    setLiteData(prev => ({
+      ...prev,
+      [yearNum]: { ...prev[yearNum], [field]: value },
+    }));
+  };
+
+  const handleLiteKeyDown = (
+    e: React.KeyboardEvent<HTMLInputElement>,
+    type: "grade" | "units",
+    yearNum: number
+  ) => {
+    const keys = ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"];
+    if (!keys.includes(e.key)) return;
+    e.preventDefault();
+
+    let nextId = "";
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      if (type === "grade") {
+        nextId = showUnits ? `lite-year-${yearNum}-units` : (yearNum < 4 ? `lite-year-${yearNum + 1}-grade` : "");
+      } else if (yearNum < 4) {
+        nextId = `lite-year-${yearNum + 1}-grade`;
       }
-    });
-
-    // Calculate year statistics
-    Object.entries(yearGroups).forEach(([year, termRows]) => {
-      const allRows = termRows.flat();
-      const validRows = allRows.filter(row => {
-        if (!row) return false;
-        const isNatSer = (row.subjectCode || '').toUpperCase().startsWith('NATSER');
-        if (isNatSer) return false;
-        return row.subjectCode.trim() !== '' && row.grade.trim() !== '' && row.unit > 0;
-      });
-
-      if (validRows.length > 0) {
-        const totalHonorPoints = validRows.reduce((sum, row) => sum + row.honorPoints, 0);
-        const totalUnits = validRows.reduce((sum, row) => sum + Number(row.unit), 0);
-        const gpa = totalUnits > 0 ? totalHonorPoints / totalUnits : 0;
-        const totalRGrades = validRows.filter(row => row.grade.toUpperCase() === 'R').length;
-
-        newYearStats[year] = {
-          gpa: gpa,
-          totalHonorPoints,
-          totalUnits,
-          rGrades: totalRGrades
-        };
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      if (type === "units") {
+        nextId = `lite-year-${yearNum}-grade`;
+      } else if (yearNum > 1) {
+        nextId = showUnits ? `lite-year-${yearNum - 1}-units` : `lite-year-${yearNum - 1}-grade`;
       }
-    });
+    }
 
-    setYearStats(newYearStats);
-  }, [termsData]);
+    if (nextId) {
+      const el = document.getElementById(nextId) as HTMLInputElement;
+      if (el) { el.focus(); el.select(); }
+    }
+  };
 
   const tableLayout = [
     ["Year 1 Term 1", "Year 1 Term 2", "Year 1 Term 3"],
@@ -120,290 +238,257 @@ export default function LatinHonorsCalculator() {
     let nextCellCol = fromCol;
 
     if (direction === "left" && fromCol === 0) {
-      if (termColIndex > 0) {
-        nextTermName = tableLayout[termRowIndex][termColIndex - 1];
-        nextCellCol = 2; // Last editable column
-      }
+      if (termColIndex > 0) { nextTermName = tableLayout[termRowIndex][termColIndex - 1]; nextCellCol = 2; }
     } else if (direction === "right" && fromCol === 2) {
-      if (termColIndex < tableLayout[termRowIndex].length - 1) {
-        nextTermName = tableLayout[termRowIndex][termColIndex + 1];
-        nextCellCol = 0; // First column
-      }
+      if (termColIndex < tableLayout[termRowIndex].length - 1) { nextTermName = tableLayout[termRowIndex][termColIndex + 1]; nextCellCol = 0; }
     } else if (direction === "up" && fromRow === 0) {
-      if (termRowIndex > 0) {
-        nextTermName = tableLayout[termRowIndex - 1][termColIndex];
-        const targetRows = termsData[nextTermName] || [];
-        nextCellRow = Math.max(0, targetRows.length - 1);
-      }
+      if (termRowIndex > 0) { nextTermName = tableLayout[termRowIndex - 1][termColIndex]; const targetRows = termsData[nextTermName] || []; nextCellRow = Math.max(0, targetRows.length - 1); }
     } else if (direction === "down" && fromRow === (termsData[fromTerm]?.length || 0) - 1) {
-      if (termRowIndex < tableLayout.length - 1) {
-        nextTermName = tableLayout[termRowIndex + 1][termColIndex];
-        nextCellRow = 0;
-      }
+      if (termRowIndex < tableLayout.length - 1) { nextTermName = tableLayout[termRowIndex + 1][termColIndex]; nextCellRow = 0; }
     }
 
     if (nextTermName) {
       const nextTermRows = termsData[nextTermName] || [];
-      if (nextTermRows.length > 0 && nextCellRow >= nextTermRows.length) {
-        nextCellRow = nextTermRows.length - 1;
-      }
-      if (nextCellRow < 0 || nextTermRows.length === 0) {
-        nextCellRow = 0;
-      }
-
+      if (nextTermRows.length > 0 && nextCellRow >= nextTermRows.length) nextCellRow = nextTermRows.length - 1;
+      if (nextCellRow < 0 || nextTermRows.length === 0) nextCellRow = 0;
       const nextCellId = `cell-${nextTermName}-${nextCellRow}-${nextCellCol}`;
-      const targetInput = document.getElementById(nextCellId) as HTMLInputElement;
-      if (targetInput) {
-        targetInput.focus();
-        targetInput.select();
-      }
+      const el = document.getElementById(nextCellId) as HTMLInputElement;
+      if (el) { el.focus(); el.select(); }
     }
   };
 
-  // Recalculate overall results whenever yearStats changes so outputs are live
-  
-
-  const calculateLatinHonors = React.useCallback(() => {
-    const years = Object.values(yearStats);
-
-    if (years.length === 0) {
-      setOverallGPA("0.00");
-      setLatinHonor("-");
-      return;
-    }
-
-    // Calculate overall GPA across all years
-    const totalGPA = years.reduce((sum, year) => sum + year.gpa, 0);
-    const averageGPA = totalGPA / years.length;
-
-    // Calculate total units across all years
-    const totalUnits = years.reduce((sum, year) => sum + year.totalUnits, 0);
-    const hasEnoughUnits = totalUnits >= 144; // 144 units required for Latin honors (4 years * 36 units)
-
-    // Calculate total R grades across all years
-    const totalRGrades = years.reduce((sum, year) => sum + year.rGrades, 0);
-    const hasTooManyRs = totalRGrades > 8; // Maximum 8 R grades allowed for Latin honors (2 per year * 4 years)
-
-    setOverallGPA(averageGPA.toFixed(2));
-
-    if (!hasEnoughUnits) {
-      setLatinHonor("No, not enough units");
-      return;
-    }
-
-    if (hasTooManyRs) {
-      setLatinHonor("No, more than 8 R grades");
-      return;
-    }
-
-    // Determine Latin honor based on GPA
-    if (averageGPA >= 3.85) {
-      setLatinHonor("Summa Cum Laude");
-    } else if (averageGPA >= 3.70) {
-      setLatinHonor("Magna Cum Laude");
-    } else if (averageGPA >= 3.50) {
-      setLatinHonor("Cum Laude");
+  const results = React.useMemo(() => {
+    if (liteMode) {
+      const years = Object.values(liteData);
+      const validGPA = years.map(y => parseFloat(y.gpa)).filter(v => !isNaN(v) && v > 0);
+      const totalUnits = years.reduce((sum, y) => sum + (parseFloat(y.units) || 0), 0);
+      
+      const avgGPA = validGPA.length > 0 ? validGPA.reduce((a, b) => a + b, 0) / validGPA.length : 0;
+      
+      let eligible = "-";
+      if (validGPA.length > 0) {
+        if (showUnits && totalUnits < 144) {
+          eligible = "No, not enough units (need 144)";
+        } else if (avgGPA >= 3.85) {
+          eligible = "Summa Cum Laude";
+        } else if (avgGPA >= 3.70) {
+          eligible = "Magna Cum Laude";
+        } else if (avgGPA >= 3.50) {
+          eligible = "Cum Laude";
+        } else {
+          eligible = "No Latin Honor";
+        }
+      }
+      return { gpa: avgGPA.toFixed(2), latinHonor: eligible, units: totalUnits };
     } else {
-      setLatinHonor("No Latin Honor");
-    }
-  }, [yearStats]);
+      // Full Mode logic
+      let totalHonorPoints = 0;
+      let totalUnits = 0;
+      let totalRGrades = 0;
+      let yearCount = 0;
 
-  // Recalculate overall results whenever yearStats changes so outputs are live
-  React.useEffect(() => {
-    calculateLatinHonors();
-  }, [calculateLatinHonors]);
+      const yearSums: Record<string, { points: number, units: number, rs: number }> = {};
+
+      Object.entries(termsData).forEach(([term, rows]) => {
+        const year = term.split(' ').slice(0, 2).join(' ');
+        if (!yearSums[year]) yearSums[year] = { points: 0, units: 0, rs: 0 };
+        
+        rows.filter(r => {
+          const isNatSer = (r.subjectCode || '').toUpperCase().startsWith('NATSER');
+          return !isNatSer && r.subjectCode.trim() !== '' && r.grade.trim() !== '' && r.unit > 0;
+        }).forEach(r => {
+          yearSums[year].points += r.honorPoints;
+          yearSums[year].units += Number(r.unit);
+          if (r.grade.toUpperCase() === 'R') yearSums[year].rs += 1;
+        });
+      });
+
+      const yearGPAs = Object.values(yearSums)
+        .filter(y => y.units > 0)
+        .map(y => y.points / y.units);
+      
+      const combinedUnits = Object.values(yearSums).reduce((s, y) => s + y.units, 0);
+      const combinedRs = Object.values(yearSums).reduce((s, y) => s + y.rs, 0);
+      const averageGPA = yearGPAs.length > 0 ? yearGPAs.reduce((a, b) => a + b, 0) / yearGPAs.length : 0;
+
+      let eligible = "-";
+      if (yearGPAs.length > 0) {
+        if (combinedUnits < 144) eligible = "No, not enough units";
+        else if (combinedRs > 8) eligible = "No, more than 8 R grades";
+        else if (averageGPA >= 3.85) eligible = "Summa Cum Laude";
+        else if (averageGPA >= 3.70) eligible = "Magna Cum Laude";
+        else if (averageGPA >= 3.50) eligible = "Cum Laude";
+        else eligible = "No Latin Honor";
+      }
+
+      return { gpa: averageGPA.toFixed(2), latinHonor: eligible, units: combinedUnits };
+    }
+  }, [liteMode, liteData, termsData, showUnits]);
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Header */}
       <header className="border-b bg-card">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-            <Link href="/">
-              <Button variant="ghost" size="sm" className="p-2">
-                <ArrowLeft className="h-4 w-4" />
-              </Button>
-            </Link>
-            <h1 className="text-sm text-muted-foreground">Latin Honors Calculator</h1>
+              <Link href="/">
+                <Button variant="ghost" size="sm" className="p-2">
+                  <ArrowLeft className="h-4 w-4" />
+                </Button>
+              </Link>
+              <h1 className="text-sm text-muted-foreground">Latin Honors Calculator</h1>
             </div>
             <ThemeToggle />
           </div>
         </div>
       </header>
 
-      {/* Main Content */}
       <main className="container mx-auto px-4 py-16">
-        {/* Hero Section */}
         <div className="text-center mb-10">
           <div className="flex justify-center mb-4">
             <Calculator className="h-12 w-12 text-muted-foreground" />
           </div>
-          <h1 className="text-4xl font-normal text-foreground mb-4">
-            Latin Honors Calculator
-          </h1>
+          <h1 className="text-4xl font-normal text-foreground mb-4">Latin Honors Calculator</h1>
           <p className="text-muted-foreground text-lg">
-            Calculate your 4-year academic performance for Latin honors <br />
-            You can just use the arrow keys on your keyboard for easier navigation ^^ <br />
-            (Click on an input box first then you can use the arrow keys!)
+            <AnimatePresence mode="wait">
+              <motion.span
+                key={liteMode ? "lite" : "full"}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.2 }}
+              >
+                {liteMode ? (
+                  <>Enter your general average for each school year</>
+                ) : (
+                  <>Enter subjects and grades for all four years</>
+                )}
+              </motion.span>
+            </AnimatePresence>
           </p>
-        </div>
 
-
-        {/* Overall Statistics Display */}
-        <div className="flex justify-center mt-8 gap-4">
-          <div className="border px-4 py-2 shadow-sm rounded">Overall GPA: {overallGPA}</div>
-          <div className="border px-4 py-2 shadow-sm rounded">Latin Honor: {latinHonor}</div>
-        </div>
-
-        {/* Year 1 */}
-        <div className="mt-12">
-          <h2 className="text-2xl font-semibold mb-6 text-center">Year 1</h2>
-          <div className="grid md:grid-cols-3 gap-4 justify-center">
-            <TermTable 
-              term="Year 1 Term 1" 
-              initialRows={termsData["Year 1 Term 1"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 1 Term 2" 
-              initialRows={termsData["Year 1 Term 2"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 1 Term 3" 
-              initialRows={termsData["Year 1 Term 3"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
+          <div className="flex items-center justify-center gap-2.5 mt-6">
+            <button
+              role="checkbox"
+              aria-checked={liteMode}
+              onClick={() => setLiteMode(prev => !prev)}
+              className={`relative inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded border-2 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ${liteMode ? 'bg-foreground border-foreground' : 'bg-background border-input hover:border-foreground/50'}`}
+            >
+              {liteMode && <svg className="h-3 w-3 text-background" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>}
+            </button>
+            <label onClick={() => setLiteMode(prev => !prev)} className="flex items-center gap-1.5 text-sm text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors">
+              <Zap className="h-3.5 w-3.5" /> Lite Mode
+            </label>
           </div>
-          {/* Year 1 Summary */}
-          {yearStats["Year 1"] && (
-            <div className="flex justify-center mt-4 gap-4">
-              <div className="border px-4 py-2 shadow-sm rounded bg-blue-50">
-                Year 1 GPA: {yearStats["Year 1"].gpa.toFixed(2)}
-              </div>
-              <div className="border px-4 py-2 shadow-sm rounded bg-blue-50">
-                Year 1 Units: {yearStats["Year 1"].totalUnits}
-              </div>
-            </div>
-          )}
         </div>
 
-        {/* Year 2 */}
-        <div className="mt-12">
-          <h2 className="text-2xl font-semibold mb-6 text-center">Year 2</h2>
-          <div className="grid md:grid-cols-3 gap-4 justify-center">
-            <TermTable 
-              term="Year 2 Term 1" 
-              initialRows={termsData["Year 2 Term 1"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 2 Term 2" 
-              initialRows={termsData["Year 2 Term 2"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 2 Term 3" 
-              initialRows={termsData["Year 2 Term 3"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-          </div>
-          {/* Year 2 Summary */}
-          {yearStats["Year 2"] && (
-            <div className="flex justify-center mt-4 gap-4">
-              <div className="border px-4 py-2 shadow-sm rounded bg-green-50">
-                Year 2 GPA: {yearStats["Year 2"].gpa.toFixed(2)}
-              </div>
-              <div className="border px-4 py-2 shadow-sm rounded bg-green-50">
-                Year 2 Units: {yearStats["Year 2"].totalUnits}
-              </div>
-            </div>
-          )}
+        {/* Global Results at the top */}
+        <div className="flex justify-center mb-12">
+          <motion.div 
+            layout 
+            className="flex gap-4 flex-wrap justify-center items-center p-6 rounded-xl border bg-card/50 shadow-sm"
+          >
+            <motion.div layout className="flex flex-col items-center px-6 py-2 border-r border-border/50 last:border-0">
+              <p className="text-sm text-muted-foreground mb-1">Overall GPA</p>
+              <p className="text-3xl font-bold tracking-tight">{results.gpa}</p>
+            </motion.div>
+            
+            <AnimatePresence mode="popLayout">
+              {liteMode && showUnits && (
+                <motion.div 
+                  layout
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  className="flex flex-col items-center px-6 py-2 border-r border-border/50 last:border-0"
+                >
+                  <p className="text-sm text-muted-foreground mb-1">Total Units</p>
+                  <p className="text-3xl font-bold tracking-tight">{results.units}</p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+
+            <motion.div layout className="flex flex-col items-center px-6 py-2">
+              <p className="text-sm text-muted-foreground mb-1">Latin Honor Status</p>
+              <p className="text-3xl font-bold tracking-tight text-primary">{results.latinHonor}</p>
+            </motion.div>
+          </motion.div>
         </div>
 
-        {/* Year 3 */}
-        <div className="mt-12">
-          <h2 className="text-2xl font-semibold mb-6 text-center">Year 3</h2>
-          <div className="grid md:grid-cols-3 gap-4 justify-center">
-            <TermTable 
-              term="Year 3 Term 1" 
-              initialRows={termsData["Year 3 Term 1"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 3 Term 2" 
-              initialRows={termsData["Year 3 Term 2"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 3 Term 3" 
-              initialRows={termsData["Year 3 Term 3"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-          </div>
-          {/* Year 3 Summary */}
-          {yearStats["Year 3"] && (
-            <div className="flex justify-center mt-4 gap-4">
-              <div className="border px-4 py-2 shadow-sm rounded bg-yellow-50">
-                Year 3 GPA: {yearStats["Year 3"].gpa.toFixed(2)}
-              </div>
-              <div className="border px-4 py-2 shadow-sm rounded bg-yellow-50">
-                Year 3 Units: {yearStats["Year 3"].totalUnits}
-              </div>
-            </div>
-          )}
-        </div>
+        <hr className="mb-10 border-border/100" />
 
-        {/* Year 4 */}
-        <div className="mt-12">
-          <h2 className="text-2xl font-semibold mb-6 text-center">Year 4</h2>
-          <div className="grid md:grid-cols-3 gap-4 justify-center">
-            <TermTable 
-              term="Year 4 Term 1" 
-              initialRows={termsData["Year 4 Term 1"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 4 Term 2" 
-              initialRows={termsData["Year 4 Term 2"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-            <TermTable 
-              term="Year 4 Term 3" 
-              initialRows={termsData["Year 4 Term 3"]}
-              onStatsChange={handleTermChange}
-              onEdge={handleEdge}
-            />
-          </div>
-          {/* Year 4 Summary */}
-          {yearStats["Year 4"] && (
-            <div className="flex justify-center mt-4 gap-4">
-              <div className="border px-4 py-2 shadow-sm rounded bg-purple-50">
-                Year 4 GPA: {yearStats["Year 4"].gpa.toFixed(2)}
+        <AnimatePresence mode="wait">
+          {liteMode ? (
+            <motion.div
+              key="lite-content"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="max-w-4xl mx-auto"
+            >
+              <div className="rounded-xl border bg-card p-8 shadow-sm">
+                <div className="flex items-center justify-between mb-8">
+                  <h3 className="text-xl font-medium">Yearly Performance</h3>
+                  <div className="flex items-center gap-2">
+                    <label htmlFor="latin-units-toggle" className="text-xs text-muted-foreground cursor-pointer select-none">Include Units?</label>
+                    <input
+                      id="latin-units-toggle"
+                      type="checkbox"
+                      checked={showUnits}
+                      onChange={e => setShowUnits(e.target.checked)}
+                      className="w-3.5 h-3.5 rounded border-input text-foreground focus:ring-ring cursor-pointer"
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+                  {[1, 2, 3, 4].map(num => (
+                    <LiteYearRow
+                      key={num}
+                      yearNum={num}
+                      gradeValue={liteData[num].gpa}
+                      unitsValue={liteData[num].units}
+                      onGradeChange={v => handleLiteChange(num, "gpa", v)}
+                      onUnitsChange={v => handleLiteChange(num, "units", v)}
+                      onKeyDown={handleLiteKeyDown}
+                      showUnits={showUnits}
+                    />
+                  ))}
+                </div>
               </div>
-              <div className="border px-4 py-2 shadow-sm rounded bg-purple-50">
-                Year 4 Units: {yearStats["Year 4"].totalUnits}
-              </div>
-            </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="full-content"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              className="space-y-16"
+            >
+              {[1, 2, 3, 4].map(yNum => (
+                <section key={yNum} className="space-y-8">
+                  <div className="flex items-center justify-center gap-4">
+                    <div className="h-px bg-border flex-1" />
+                    <h2 className="text-2xl font-semibold px-4">Year {yNum}</h2>
+                    <div className="h-px bg-border flex-1" />
+                  </div>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                    {[1, 2, 3].map(tNum => (
+                      <MemoizedTermTable
+                        key={`${yNum}-${tNum}`}
+                        term={`Year ${yNum} Term ${tNum}`}
+                        initialRows={termsData[`Year ${yNum} Term ${tNum}`]}
+                        onStatsChange={handleTermChange}
+                        onEdge={handleEdge}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </motion.div>
           )}
-        </div>
+        </AnimatePresence>
 
-        {/* Results are calculated live as you edit terms; no manual button required. */}
-    
-        {/* Footer */}
-        <footer className="border-t pt-8 mt-16">
+        <footer className="border-t pt-8 mt-24">
           <p className="text-center text-xs text-muted-foreground">
             Created by the Developers of JPCS - APC | Edwin Gumba Jr. (SS221) & Marwin John Gonzales (IT241)
           </p>

--- a/src/app/latin-honors/page.tsx
+++ b/src/app/latin-honors/page.tsx
@@ -17,20 +17,20 @@ interface RowData {
   honorPoints: number;
 }
 
-interface YearStats {
-  gpa: number;
-  totalHonorPoints: number;
-  totalUnits: number;
-  rGrades: number;
+// Lite Mode: per-term general averages (3 terms each year, for 4 years)
+interface LiteYearData {
+  term1: string;
+  term2: string;
+  term3: string;
+  units1: string;
+  units2: string;
+  units3: string;
 }
 
-interface LiteYearInput {
-  gpa: string;
-  units: string;
-}
-
-// ── Lite Mode row for Latin Honors (one year per row/cell) ──
-function LiteYearRow({
+// ── Lite Mode Term Row ──
+function LiteTermRow({
+  termNum,
+  yearKey,
   yearNum,
   gradeValue,
   unitsValue,
@@ -39,6 +39,8 @@ function LiteYearRow({
   onKeyDown,
   showUnits,
 }: {
+  termNum: number;
+  yearKey: string;
   yearNum: number;
   gradeValue: string;
   unitsValue: string;
@@ -47,36 +49,37 @@ function LiteYearRow({
   onKeyDown: (
     e: React.KeyboardEvent<HTMLInputElement>,
     type: "grade" | "units",
+    termNum: number,
     yearNum: number
   ) => void;
   showUnits: boolean;
 }) {
   return (
     <div className="flex flex-col gap-1.5">
-      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-        Year {yearNum}
+      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+        Term {termNum}
       </p>
 
       <div className="flex items-end gap-2">
         <div className="flex flex-col gap-1 flex-1">
           <label
-            htmlFor={`lite-year-${yearNum}-grade`}
-            className="text-xs text-muted-foreground font-medium"
+            htmlFor={`lite-year-${yearNum}-term-${termNum}-grade`}
+            className="text-[10px] text-muted-foreground font-medium"
           >
             GPA
           </label>
           <input
-            id={`lite-year-${yearNum}-grade`}
+            id={`lite-year-${yearNum}-term-${termNum}-grade`}
             type="number"
             step="0.01"
             min="0"
             max="5"
             value={gradeValue}
             onChange={e => onGradeChange(e.target.value)}
-            onKeyDown={e => onKeyDown(e, "grade", yearNum)}
+            onKeyDown={e => onKeyDown(e, "grade", termNum, yearNum)}
             placeholder="0.00"
             className="
-              w-full rounded-md border border-input bg-background px-3 py-1.5
+              w-full rounded-md border border-input bg-background px-2.5 py-1
               text-sm text-foreground shadow-sm
               placeholder:text-muted-foreground/50
               focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
@@ -89,27 +92,27 @@ function LiteYearRow({
           {showUnits && (
             <motion.div
               initial={{ opacity: 0, width: 0, x: 10 }}
-              animate={{ opacity: 1, width: 64, x: 0 }}
+              animate={{ opacity: 1, width: 50, x: 0 }}
               exit={{ opacity: 0, width: 0, x: 10 }}
               className="flex flex-col gap-1 overflow-hidden"
             >
               <label
-                htmlFor={`lite-year-${yearNum}-units`}
-                className="text-xs text-muted-foreground font-medium whitespace-nowrap"
+                htmlFor={`lite-year-${yearNum}-term-${termNum}-units`}
+                className="text-[10px] text-muted-foreground font-medium whitespace-nowrap"
               >
                 Units
               </label>
               <input
-                id={`lite-year-${yearNum}-units`}
+                id={`lite-year-${yearNum}-term-${termNum}-units`}
                 type="number"
                 step="1"
                 min="0"
                 value={unitsValue}
                 onChange={e => onUnitsChange(e.target.value)}
-                onKeyDown={e => onKeyDown(e, "units", yearNum)}
+                onKeyDown={e => onKeyDown(e, "units", termNum, yearNum)}
                 placeholder="0"
                 className="
-                  w-full rounded-md border border-input bg-background px-2 py-1.5
+                  w-full rounded-md border border-input bg-background px-2 py-1
                   text-sm text-center text-foreground shadow-sm
                   placeholder:text-muted-foreground/50
                   focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent
@@ -128,11 +131,11 @@ export default function LatinHonorsCalculator() {
   const [termsData, setTermsData] = React.useState<Record<string, RowData[]>>({});
   const [liteMode, setLiteMode] = React.useState(true);
   const [showUnits, setShowUnits] = React.useState(false);
-  const [liteData, setLiteData] = React.useState<Record<number, LiteYearInput>>({
-    1: { gpa: "", units: "" },
-    2: { gpa: "", units: "" },
-    3: { gpa: "", units: "" },
-    4: { gpa: "", units: "" },
+  const [liteData, setLiteData] = React.useState<Record<number, LiteYearData>>({
+    1: { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    2: { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    3: { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
+    4: { term1: "", term2: "", term3: "", units1: "", units2: "", units3: "" },
   });
 
   const termsDataRef = React.useRef(termsData);
@@ -179,7 +182,7 @@ export default function LatinHonorsCalculator() {
     setTermsData(prev => ({ ...prev, [term]: rows }));
   }, []);
 
-  const handleLiteChange = (yearNum: number, field: keyof LiteYearInput, value: string) => {
+  const handleLiteChange = (yearNum: number, field: keyof LiteYearData, value: string) => {
     setLiteData(prev => ({
       ...prev,
       [yearNum]: { ...prev[yearNum], [field]: value },
@@ -189,6 +192,7 @@ export default function LatinHonorsCalculator() {
   const handleLiteKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
     type: "grade" | "units",
+    termNum: number,
     yearNum: number
   ) => {
     const keys = ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"];
@@ -198,15 +202,19 @@ export default function LatinHonorsCalculator() {
     let nextId = "";
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       if (type === "grade") {
-        nextId = showUnits ? `lite-year-${yearNum}-units` : (yearNum < 4 ? `lite-year-${yearNum + 1}-grade` : "");
+        nextId = showUnits ? `lite-year-${yearNum}-term-${termNum}-units` : (termNum < 3 ? `lite-year-${yearNum}-term-${termNum + 1}-grade` : (yearNum < 4 ? `lite-year-${yearNum + 1}-term-1-grade` : ""));
+      } else if (termNum < 3) {
+        nextId = `lite-year-${yearNum}-term-${termNum + 1}-grade`;
       } else if (yearNum < 4) {
-        nextId = `lite-year-${yearNum + 1}-grade`;
+        nextId = `lite-year-${yearNum + 1}-term-1-grade`;
       }
     } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
       if (type === "units") {
-        nextId = `lite-year-${yearNum}-grade`;
+        nextId = `lite-year-${yearNum}-term-${termNum}-grade`;
+      } else if (termNum > 1) {
+        nextId = showUnits ? `lite-year-${yearNum}-term-${termNum - 1}-units` : `lite-year-${yearNum}-term-${termNum - 1}-grade`;
       } else if (yearNum > 1) {
-        nextId = showUnits ? `lite-year-${yearNum - 1}-units` : `lite-year-${yearNum - 1}-grade`;
+        nextId = showUnits ? `lite-year-${yearNum - 1}-term-3-units` : `lite-year-${yearNum - 1}-term-3-grade`;
       }
     }
 
@@ -260,29 +268,40 @@ export default function LatinHonorsCalculator() {
   const results = React.useMemo(() => {
     if (liteMode) {
       const years = Object.values(liteData);
-      const validGPA = years.map(y => parseFloat(y.gpa)).filter(v => !isNaN(v) && v > 0);
-      const totalUnits = years.reduce((sum, y) => sum + (parseFloat(y.units) || 0), 0);
       
-      const avgGPA = validGPA.length > 0 ? validGPA.reduce((a, b) => a + b, 0) / validGPA.length : 0;
+      const allTermGPAs: number[] = [];
+      let totalUnits = 0;
+
+      years.forEach(year => {
+        [1, 2, 3].forEach(termNum => {
+          const gpaVal = parseFloat(year[`term${termNum}` as keyof LiteYearData]);
+          const unitVal = parseFloat(year[`units${termNum}` as keyof LiteYearData]) || 0;
+          if (!isNaN(gpaVal) && gpaVal > 0) {
+            allTermGPAs.push(gpaVal);
+          }
+          totalUnits += unitVal;
+        });
+      });
+      
+      const averageGPA = allTermGPAs.length > 0 ? allTermGPAs.reduce((a, b) => a + b, 0) / allTermGPAs.length : 0;
       
       let eligible = "-";
-      if (validGPA.length > 0) {
+      if (allTermGPAs.length > 0) {
         if (showUnits && totalUnits < 144) {
           eligible = "No, not enough units (need 144)";
-        } else if (avgGPA >= 3.85) {
+        } else if (averageGPA >= 3.85) {
           eligible = "Summa Cum Laude";
-        } else if (avgGPA >= 3.70) {
+        } else if (averageGPA >= 3.70) {
           eligible = "Magna Cum Laude";
-        } else if (avgGPA >= 3.50) {
+        } else if (averageGPA >= 3.50) {
           eligible = "Cum Laude";
         } else {
           eligible = "No Latin Honor";
         }
       }
-      return { gpa: avgGPA.toFixed(2), latinHonor: eligible, units: totalUnits };
+      return { gpa: averageGPA.toFixed(2), latinHonor: eligible, units: totalUnits };
     } else {
       // Full Mode logic
-      let totalHonorPoints = 0;
       let totalUnits = 0;
       let totalRGrades = 0;
 
@@ -358,7 +377,7 @@ export default function LatinHonorsCalculator() {
                 transition={{ duration: 0.2 }}
               >
                 {liteMode ? (
-                  <>Enter your general average for each school year</>
+                  <>Enter your general average for each term across all four years</>
                 ) : (
                   <>Enter subjects and grades for all four years</>
                 )}
@@ -425,9 +444,9 @@ export default function LatinHonorsCalculator() {
               exit={{ opacity: 0, y: -20 }}
               className="max-w-4xl mx-auto"
             >
-              <div className="rounded-xl border bg-card p-8 shadow-sm">
-                <div className="flex items-center justify-between mb-8">
-                  <h3 className="text-xl font-medium">Yearly Performance</h3>
+              <div className="rounded-xl border bg-card p-6 shadow-sm overflow-x-auto">
+                <div className="flex items-center justify-between mb-8 px-2">
+                  <h3 className="text-xl font-medium">12-Term Performance Grid</h3>
                   <div className="flex items-center gap-2">
                     <label htmlFor="latin-units-toggle" className="text-xs text-muted-foreground cursor-pointer select-none">Include Units?</label>
                     <input
@@ -439,18 +458,31 @@ export default function LatinHonorsCalculator() {
                     />
                   </div>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-                  {[1, 2, 3, 4].map(num => (
-                    <LiteYearRow
-                      key={num}
-                      yearNum={num}
-                      gradeValue={liteData[num].gpa}
-                      unitsValue={liteData[num].units}
-                      onGradeChange={v => handleLiteChange(num, "gpa", v)}
-                      onUnitsChange={v => handleLiteChange(num, "units", v)}
-                      onKeyDown={handleLiteKeyDown}
-                      showUnits={showUnits}
-                    />
+                
+                <div className="space-y-10">
+                  {[1, 2, 3, 4].map(yNum => (
+                    <div key={yNum} className="space-y-4">
+                      <div className="flex items-center gap-4 px-2">
+                        <span className="text-sm font-semibold text-foreground whitespace-nowrap">Year {yNum}</span>
+                        <div className="h-px bg-border/50 flex-1" />
+                      </div>
+                      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        {[1, 2, 3].map(tNum => (
+                          <LiteTermRow
+                            key={tNum}
+                            termNum={tNum}
+                            yearNum={yNum}
+                            yearKey={`Year ${yNum}`}
+                            gradeValue={liteData[yNum][`term${tNum}` as keyof LiteYearData]}
+                            unitsValue={liteData[yNum][`units${tNum}` as keyof LiteYearData]}
+                            onGradeChange={v => handleLiteChange(yNum, `term${tNum}` as keyof LiteYearData, v)}
+                            onUnitsChange={v => handleLiteChange(yNum, `units${tNum}` as keyof LiteYearData, v)}
+                            onKeyDown={handleLiteKeyDown}
+                            showUnits={showUnits}
+                          />
+                        ))}
+                      </div>
+                    </div>
                   ))}
                 </div>
               </div>

--- a/src/app/latin-honors/page.tsx
+++ b/src/app/latin-honors/page.tsx
@@ -285,7 +285,6 @@ export default function LatinHonorsCalculator() {
       let totalHonorPoints = 0;
       let totalUnits = 0;
       let totalRGrades = 0;
-      let yearCount = 0;
 
       const yearSums: Record<string, { points: number, units: number, rs: number }> = {};
 
@@ -313,7 +312,7 @@ export default function LatinHonorsCalculator() {
 
       let eligible = "-";
       if (yearGPAs.length > 0) {
-        if (combinedUnits < 144) eligible = "No, not enough units";
+        if (combinedUnits < 144) eligible = "No, not enough units (need 144)";
         else if (combinedRs > 8) eligible = "No, more than 8 R grades";
         else if (averageGPA >= 3.85) eligible = "Summa Cum Laude";
         else if (averageGPA >= 3.70) eligible = "Magna Cum Laude";
@@ -386,21 +385,21 @@ export default function LatinHonorsCalculator() {
         <div className="flex justify-center mb-12">
           <motion.div 
             layout 
-            className="flex gap-4 flex-wrap justify-center items-center p-6 rounded-xl border bg-card/50 shadow-sm"
+            className="flex gap-0 flex-wrap justify-center items-center p-6 rounded-xl border bg-card/50 shadow-sm"
           >
-            <motion.div layout className="flex flex-col items-center px-6 py-2 border-r border-border/50 last:border-0">
+            <motion.div layout className="flex flex-col items-center px-8 py-2 border-r border-border/50 last:border-0">
               <p className="text-sm text-muted-foreground mb-1">Overall GPA</p>
               <p className="text-3xl font-bold tracking-tight">{results.gpa}</p>
             </motion.div>
             
             <AnimatePresence mode="popLayout">
-              {liteMode && showUnits && (
+              {(!liteMode || showUnits) && (
                 <motion.div 
                   layout
                   initial={{ opacity: 0, scale: 0.8 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.8 }}
-                  className="flex flex-col items-center px-6 py-2 border-r border-border/50 last:border-0"
+                  className="flex flex-col items-center px-8 py-2 border-r border-border/50 last:border-0"
                 >
                   <p className="text-sm text-muted-foreground mb-1">Total Units</p>
                   <p className="text-3xl font-bold tracking-tight">{results.units}</p>
@@ -408,7 +407,7 @@ export default function LatinHonorsCalculator() {
               )}
             </AnimatePresence>
 
-            <motion.div layout className="flex flex-col items-center px-6 py-2">
+            <motion.div layout className="flex flex-col items-center px-8 py-2">
               <p className="text-sm text-muted-foreground mb-1">Latin Honor Status</p>
               <p className="text-3xl font-bold tracking-tight text-primary">{results.latinHonor}</p>
             </motion.div>


### PR DESCRIPTION
<img width="803" height="787" alt="image" src="https://github.com/user-attachments/assets/f0bea34f-a595-4ec9-a30b-7d25dee45eff" />

Solving Issue #136 and #137

## Testing / Verification
- Verified **Lite Mode** UI + calculations for:
  - **Honors Calculator** (`/honors`)
  - **Latin Honors Calculator** (`/latin-honors`)
- Confirmed values persist via `localStorage` for both modes (Lite + Full).
- Tested keyboard navigation improvements (arrow keys) for Lite inputs and existing table navigation for Full mode.

---

## Release Notes

### Lite Mode (New)
Introduced a **Lite Mode** that lets users quickly compute eligibility by entering **general averages per term** instead of encoding every subject.

#### Honors Calculator (`/honors`)
- Added **Lite Mode toggle** in the hero section.
- Lite Mode supports:
  - **Year 1** quick-entry (3 terms) using general average inputs
  - Optional **Units** input (animated in/out)
  - Eligibility check based on:
    - GPA average within **3.00–4.00**
    - If Units are enabled: requires **36 units**
- Includes **arrow-key navigation** between Lite inputs.
- Persists:
  - `honorsLiteData`
  - `honorsLiteMode`
  - (Full mode still persists existing `honorsTermsData`)

#### Latin Honors Calculator (`/latin-honors`)
- Added **Lite Mode toggle** + redesigned top summary cards.
- Lite Mode supports:
  - **12-term grid** (Years 1–4, Terms 1–3)
  - Optional **Units** input (animated in/out)
  - Overall GPA computed as the average of all entered term GPAs
  - Honor status computed live:
    - **Summa Cum Laude / Magna / Cum Laude / Academic Distinction**
    - If Units are enabled: requires **144 units**
- Added **keyboard navigation** across the full Lite grid (supports moving across terms + years).
- Persists:
  - `latinHonorsLiteData`
  - `latinHonorsLiteMode`
  - (Full mode still persists existing `latinHonorsTermsData`)

---

## UI / UX Improvements
- Added animations using **framer-motion** (`AnimatePresence` / `motion`) for smoother mode transitions and units field reveal.
- Updated summary displays to be more prominent and consistent across calculators.
- Cleaned up layout to match the cleaner Latin Honors UI styling.

---

## Commits (PR #135)
- `169d9e7` feat: lite mode for honors calcu  
- `fb2e2a` feat: added units and keyboard shortcuts  
- `11dc25d` feat: made units optional  
- `0681b1a` refactor: changed title to a school year  
- `a80530f` feat: draft for latin honors lite  
- `df366b9` ui: match honors UI to latin for cleaner layout  
- `1832fe9` feat: mandatory units when not in lite mode  
- `e16fb9a` ui: changed layout  
- `4eae364` feat: update Latin honor eligibility criteria and rename status label  

---

## Files Changed
- `src/app/honors/page.tsx`
- `src/app/latin-honors/page.tsx`