### PR TITLE
feat: added support for adding json for android v15 devices by adding…

### DIFF
--- a/src/app/honors-shs/page.tsx
+++ b/src/app/honors-shs/page.tsx
@@ -1037,7 +1037,7 @@ export default function SHSHonorsCalcu() {
               <input
                 ref={fileInputRef}
                 type="file"
-                accept=".json,application/json"
+                accept=".json,application/json,text/plain"
                 onChange={handleJsonImport}
                 className="hidden"
                 id="json-import-input"

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -635,7 +635,7 @@ export default function HonorsCalcu() {
               <input
                 ref={fileInputRef}
                 type="file"
-                accept=".json,application/json"
+                accept=".json,application/json,text/plain"
                 onChange={handleJsonImport}
                 className="hidden"
                 id="json-import-input"


### PR DESCRIPTION

## Description

This PR fixes an issue where Android users (specifically tested on Android 15 / Oppo Reno 10 using Chrome) are unable to select and upload their downloaded JSON grades file. #163 

The native Android file picker often disables selection of `.json` files when the input only specifies `application/json` as the accepted MIME type. Adding `text/plain` to the `accept` attribute of the file inputs resolves this issue and allows users to successfully select and upload their grade file.

# Release Notes

## Android support for JSON grade uploads
Android users can now successfully select and upload JSON files from their Downloads folder in Chrome when importing grades.
