### PR TITLE
feat: add threshold warning for honors cutoffs in Lite Mode

### DIFF
--- a/src/app/honors-shs/page.tsx
+++ b/src/app/honors-shs/page.tsx
@@ -751,9 +751,19 @@ export default function SHSHonorsCalcu() {
     return {
       overallAverage: overallAverage.toFixed(2),
       overallAward,
-      reason
+      reason,
+      rawAverage: overallAverage
     };
   }, [liteStats, liteData]);
+
+  // Lite Mode averages term grades instead of individual subject grades, so a result
+  // sitting right on an honors cutoff may flip once precise subject-level data is used.
+  const liteThresholdWarning = React.useMemo(() => {
+    if (liteSummary.rawAverage === undefined) return false;
+    const margin = 0.5;
+    const thresholds = [88.00, 93.00, 97.00];
+    return thresholds.some(t => Math.abs((liteSummary.rawAverage as number) - t) <= margin);
+  }, [liteSummary]);
 
   // Full Mode Calculation Stats
   const fullStats = React.useMemo(() => {
@@ -1102,6 +1112,14 @@ export default function SHSHonorsCalcu() {
             </p>
           )}
         </div>
+
+        {liteMode && liteThresholdWarning && (
+          <div className="flex justify-center mb-8">
+            <div className="bg-amber-500/10 border border-amber-500/30 text-amber-600 dark:text-amber-500 rounded-lg p-4 max-w-xl text-sm leading-relaxed text-center">
+              <strong>Threshold Nearing (±0.50):</strong> Your General Average is very close to an honors cutoff. Lite Mode averages term grades instead of individual subjects, so this result may be inaccurate. <strong>Check Strict Grades Mode</strong> and import your JSON grade report for a precise result.
+            </div>
+          </div>
+        )}
 
         <hr className="mb-10 border-border/100" />
 

--- a/src/app/honors/page.tsx
+++ b/src/app/honors/page.tsx
@@ -438,7 +438,7 @@ export default function HonorsCalcu() {
 
   const liteLatinHonorsSummary = React.useMemo(() => {
     const yearsWithData = Object.values(liteStats).filter(s => s.gpa > 0);
-    if (yearsWithData.length === 0) return { overallGPA: "0.00", latinHonor: "-" };
+    if (yearsWithData.length === 0) return { overallGPA: "0.00", latinHonor: "-", rawGPA: 0 };
 
     const rawAverageGPA = yearsWithData.reduce((sum, s) => sum + s.gpa, 0) / yearsWithData.length;
 
@@ -452,8 +452,17 @@ export default function HonorsCalcu() {
     else if (rawAverageGPA >= 3.40) latinHonor = "Cum Laude";
     else latinHonor = "Academic Distinction";
 
-    return { overallGPA: truncateToDecimals(rawAverageGPA, 4).toFixed(4), latinHonor };
+    return { overallGPA: truncateToDecimals(rawAverageGPA, 4).toFixed(4), latinHonor, rawGPA: rawAverageGPA };
   }, [liteStats, residencyChecked, noFailsChecked, noExcessRepeatsChecked]);
+
+  // Lite Mode averages term grades instead of individual subject grades, so a result
+  // sitting right on a Latin Honors cutoff may flip once precise subject-level data is used.
+  const liteThresholdWarning = React.useMemo(() => {
+    if (liteLatinHonorsSummary.latinHonor === "-") return false;
+    const margin = 0.02;
+    const thresholds = [3.0, 3.40, 3.60, 3.80];
+    return thresholds.some(t => Math.abs(liteLatinHonorsSummary.rawGPA - t) <= margin);
+  }, [liteLatinHonorsSummary]);
 
   const topSummaryYearKey = "Year 1";
 
@@ -710,6 +719,14 @@ export default function HonorsCalcu() {
             )}
           </AnimatePresence>
         </div>
+
+        {liteMode && liteThresholdWarning && (
+          <div className="flex justify-center mb-10">
+            <div className="bg-amber-500/10 border border-amber-500/30 text-amber-600 dark:text-amber-500 rounded-lg p-4 max-w-xl text-sm leading-relaxed text-center">
+              <strong>Threshold Nearing (±0.02):</strong> Your GPA is very close to a Latin Honors cutoff. Lite Mode averages term grades instead of individual subjects, so this result may be inaccurate. <strong>Uncheck Lite Mode</strong> to go to Full Mode and import your JSON grade report for a precise result.
+            </div>
+          </div>
+        )}
 
         {/* Honors Checklist Card */}
         <div className="flex justify-center mb-10">


### PR DESCRIPTION
## Added "Threshold Nearing" Warning for Lite Mode

### Background

Lite Mode calculates honors by averaging **term grades** instead of **individual subject grades**. Because of this approximation, results that are very close to an honors cutoff may differ from the official grade computation.

**Example:**
- Lite Mode GPA: **3.4066** → Displays **Cum Laude**
- Official computation: **Academic Distinction**

This difference occurs because the official calculation uses subject-level grades rather than term averages.

---

### Solution

Added an **amber "Threshold Nearing" warning banner** that appears **only when a Lite Mode result is very close to an honors cutoff**.

The banner advises users to switch to the more accurate calculation method before relying on the result.

---

### College Honors

**File:** `src/app/honors/page.tsx`

- Checks GPA against the following Latin Honors thresholds:
  - `3.00`
  - `3.40`
  - `3.60`
  - `3.80`
- Uses a **±0.02** tolerance margin.
- Displays the following guidance:

> Uncheck **Lite Mode** to switch to **Full Mode** and import your JSON grade report for a more accurate computation.

---

### SHS Honors

**File:** `src/app/honors-shs/page.tsx`

- Checks the General Average against the following honors thresholds:
  - `88`
  - `93`
  - `97`
- Uses a **±0.50** tolerance margin (appropriate for the 0–100 grading scale).
- Displays the following guidance:

> Enable **Strict Grades Mode** and import your JSON grade report for a more accurate computation.

---

### Implementation Details

- Added a `liteThresholdWarning` memo to both pages.
- Compared the **raw (unformatted)** Lite Mode average against each honors threshold.
- Exposed the raw average from the existing summary memo to preserve full floating-point precision during comparison.
- Styled the warning banner to match the existing amber **"Strict Grades Mode is Active"** notification for UI consistency.

---

### Verification

-  `tsc --noEmit`
- Type checking passes with no errors.

<img width="807" height="677" alt="image" src="https://github.com/user-attachments/assets/285c559b-47fe-4a74-9a91-2361e8424f99" />
